### PR TITLE
hore(ci+accessibility): add Playwright axe smoke runner, harmonize viewer/harness for reliable axe scans

### DIFF
--- a/.github/workflows/axe-playwright.yml
+++ b/.github/workflows/axe-playwright.yml
@@ -29,7 +29,7 @@ jobs:
           node-version: '18'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps

--- a/.github/workflows/axe-playwright.yml
+++ b/.github/workflows/axe-playwright.yml
@@ -16,6 +16,9 @@ jobs:
     name: Run axe across examples with Playwright
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    env:
+      # default to 'false' when not provided; workflow_dispatch may set this input
+      FAIL_ON_VIOLATIONS: ${{ github.event.inputs.fail_on_violations || 'false' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -43,7 +46,8 @@ jobs:
 
       - name: Run axe helper (Playwright)
         run: |
-          node scripts/ci-run-axe.js --base-url=http://127.0.0.1:8080 --out-dir=axe-output --fail-on-violations=false
+          echo "Running axe helper (fail on violations = ${FAIL_ON_VIOLATIONS})"
+          node scripts/ci-run-axe.js --base-url=http://127.0.0.1:8080 --out-dir=axe-output --fail-on-violations=${FAIL_ON_VIOLATIONS}
 
       - name: Show results
         run: |

--- a/.github/workflows/axe-playwright.yml
+++ b/.github/workflows/axe-playwright.yml
@@ -1,0 +1,57 @@
+name: Axe (Playwright) smoke
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+    inputs:
+      fail_on_violations:
+        description: 'Fail workflow when any axe violations are found'
+        required: false
+        default: 'false'
+
+jobs:
+  run-axe:
+    name: Run axe across examples with Playwright
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+
+      - name: Start static server
+        run: |
+          nohup npx http-server ./ -p 8080 -c-1 > server.log 2>&1 &
+          # wait until server responds on 8080 (max ~15s)
+          for i in {1..15}; do
+            if curl -sSf http://127.0.0.1:8080 >/dev/null; then
+              echo 'server up'; break
+            fi; sleep 1;
+          done
+
+      - name: Run axe helper (Playwright)
+        run: |
+          node scripts/ci-run-axe.js --base-url=http://127.0.0.1:8080 --out-dir=axe-output --fail-on-violations=false
+
+      - name: Show results
+        run: |
+          echo 'axe-output contents:'
+          ls -la axe-output || true
+
+      - name: Upload axe JSON artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: axe-output
+          path: axe-output/

--- a/.github/workflows/html-validate.yml
+++ b/.github/workflows/html-validate.yml
@@ -29,7 +29,8 @@ jobs:
         run: |
           echo "Running html-validate from project devDependencies..."
           npx html-validate --version
-          npx html-validate "jim-viewer.html" "**/*.html" || (echo "html-validate reported errors" && exit 1)
+          # Limit lint targets to project HTML files to avoid scanning node_modules
+          npx html-validate "jim-viewer.html" "tests/*.html" || (echo "html-validate reported errors" && exit 1)
 
   a11y-smoke:
     name: Accessibility smoke (pa11y)

--- a/.github/workflows/html-validate.yml
+++ b/.github/workflows/html-validate.yml
@@ -26,3 +26,32 @@ jobs:
           npx --yes html-validate --version
           # Validate the viewer and HTML files in examples
           npx --yes html-validate "jim-viewer.html" "**/*.html" || (echo "html-validate reported errors" && exit 1)
+
+  a11y-smoke:
+    name: Accessibility smoke (pa11y)
+    runs-on: ubuntu-latest
+    needs: html-validate
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Install http-server globally
+        run: |
+          npm install -g http-server
+
+      - name: Start simple static server
+        run: |
+          # serve the repository root so jim-viewer.html is reachable
+          npx http-server -p 8080 &
+          # give server a moment to start
+          sleep 2
+
+      - name: Run pa11y accessibility scan
+        # pa11y will use a headless Chromium under the hood; run against the local server
+        run: |
+          npx --yes pa11y http://127.0.0.1:8080/jim-viewer.html || (echo "pa11y reported accessibility issues" && exit 1)

--- a/.github/workflows/html-validate.yml
+++ b/.github/workflows/html-validate.yml
@@ -94,7 +94,10 @@ jobs:
             const issue_number = pr.number;
 
             const marker = '<!-- pa11y-bot-comment -->';
-            const header = `${marker}\n### pa11y accessibility scan\n\nExit code: ${exitCode}\n\n`;
+            const runId = process.env.GITHUB_RUN_ID || '';
+            const runUrl = runId ? `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${runId}` : '';
+            const runLink = runUrl ? `\n[View full artifacts and logs for this run](${runUrl})\n\n` : '\n';
+            const header = `${marker}\n### pa11y accessibility scan\n\nExit code: ${exitCode}${runLink}\n`;
             const bodyContent = (output.length > 60000 ? output.slice(0,60000) + '\n\n...truncated...' : output);
             const fullBody = header + `<details><summary>pa11y output</summary>\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\` + '```text\n' + bodyContent + '\n```\n</details>';
 

--- a/.github/workflows/html-validate.yml
+++ b/.github/workflows/html-validate.yml
@@ -20,12 +20,16 @@ jobs:
         with:
           node-version: '18'
 
-      - name: Run html-validate (via npx)
+      - name: Install dependencies
         run: |
-          echo "Running html-validate via npx..."
-          npx --yes html-validate --version
-          # Validate the viewer and HTML files in examples
-          npx --yes html-validate "jim-viewer.html" "**/*.html" || (echo "html-validate reported errors" && exit 1)
+          echo "Installing project devDependencies (html-validate)"
+          npm ci
+
+      - name: Run html-validate
+        run: |
+          echo "Running html-validate from project devDependencies..."
+          npx html-validate --version
+          npx html-validate "jim-viewer.html" "**/*.html" || (echo "html-validate reported errors" && exit 1)
 
   a11y-smoke:
     name: Accessibility smoke (pa11y)
@@ -46,12 +50,12 @@ jobs:
 
       - name: Start simple static server
         run: |
-          # serve the repository root so jim-viewer.html is reachable
+          # serve the repository root so test harness is reachable
           npx http-server -p 8080 &
           # give server a moment to start
           sleep 2
 
       - name: Run pa11y accessibility scan
-        # pa11y will use a headless Chromium under the hood; run against the local server
+        # pa11y will use a headless Chromium under the hood; run against the auto-load test harness
         run: |
-          npx --yes pa11y http://127.0.0.1:8080/jim-viewer.html || (echo "pa11y reported accessibility issues" && exit 1)
+          npx --yes pa11y http://127.0.0.1:8080/tests/auto-load.html || (echo "pa11y reported accessibility issues" && exit 1)

--- a/.github/workflows/html-validate.yml
+++ b/.github/workflows/html-validate.yml
@@ -75,46 +75,37 @@ jobs:
           name: pa11y-output
           path: pa11y-output.txt
 
-      - name: Comment on PR with pa11y output
+      - name: Comment on PR with pa11y output (update existing bot comment)
         if: always() && github.event_name == 'pull_request'
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
-            const path = 'pa11y-output.txt';
+            const outPath = 'pa11y-output.txt';
             let output = '';
-            try {
-              if (fs.existsSync(path)) {
-                output = fs.readFileSync(path, 'utf8');
-              } else {
-                output = 'No pa11y output file found.';
-              }
-            } catch (err) {
-              output = `Error reading pa11y output: ${err.message}`;
-            }
-
+            try { output = fs.existsSync(outPath) ? fs.readFileSync(outPath, 'utf8') : 'No pa11y output file found.'; } catch (err) { output = `Error reading pa11y output: ${err.message}`; }
             const exitPath = 'pa11y-exit';
             let exitCode = 'unknown';
-            try {
-              if (fs.existsSync(exitPath)) exitCode = fs.readFileSync(exitPath, 'utf8').trim();
-            } catch (e) {}
+            try { if (fs.existsSync(exitPath)) exitCode = fs.readFileSync(exitPath, 'utf8').trim(); } catch (e) {}
 
             const pr = context.payload.pull_request;
-            if (!pr) {
-              core.info('Not a pull_request event; skipping pa11y PR comment.');
-              return;
-            }
-
+            if (!pr) return;
             const issue_number = pr.number;
-            const body = `### pa11y accessibility scan\n\nExit code: ${exitCode}\n\n<details><summary>pa11y output</summary>\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\` + '```\n' + (output.length > 60000 ? output.slice(0,60000) + '\n\n...truncated...' : output) + '\n```\n</details>`;
 
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number,
-              body
-            });
+            const marker = '<!-- pa11y-bot-comment -->';
+            const header = `${marker}\n### pa11y accessibility scan\n\nExit code: ${exitCode}\n\n`;
+            const bodyContent = (output.length > 60000 ? output.slice(0,60000) + '\n\n...truncated...' : output);
+            const fullBody = header + `<details><summary>pa11y output</summary>\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\` + '```text\n' + bodyContent + '\n```\n</details>';
+
+            // List existing comments on the PR and update the bot comment if present
+            const { data: comments } = await github.rest.issues.listComments({ owner: context.repo.owner, repo: context.repo.repo, issue_number });
+            const existing = comments.find(c => c.body && c.body.startsWith(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner: context.repo.owner, repo: context.repo.repo, comment_id: existing.id, body: fullBody });
+            } else {
+              await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number, body: fullBody });
+            }
 
       - name: Fail job when pa11y failed
         if: always()

--- a/.github/workflows/html-validate.yml
+++ b/.github/workflows/html-validate.yml
@@ -48,14 +48,40 @@ jobs:
         run: |
           npm install -g http-server
 
-      - name: Start simple static server
+      - name: Run pa11y accessibility scan (capture output)
+        id: pa11y
         run: |
-          # serve the repository root so test harness is reachable
+          # Start a local static server in the background and capture its PID
           npx http-server -p 8080 &
+          SERVER_PID=$!
           # give server a moment to start
           sleep 2
 
-      - name: Run pa11y accessibility scan
-        # pa11y will use a headless Chromium under the hood; run against the auto-load test harness
+          # Run pa11y and tee output to a file. Capture the exit code so we can upload the output
+          # even if pa11y fails, then explicitly fail the job after uploading.
+          set +e
+          npx --yes pa11y http://127.0.0.1:8080/tests/auto-load.html 2>&1 | tee pa11y-output.txt
+          PA11Y_EXIT=${PIPESTATUS[0]}
+          echo "$PA11Y_EXIT" > pa11y-exit
+          set -e
+
+          # Stop the server we started
+          kill $SERVER_PID || true
+
+      - name: Upload pa11y output
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pa11y-output
+          path: pa11y-output.txt
+
+      - name: Fail job when pa11y failed
+        if: always()
         run: |
-          npx --yes pa11y http://127.0.0.1:8080/tests/auto-load.html || (echo "pa11y reported accessibility issues" && exit 1)
+          if [ -f pa11y-exit ]; then
+            code=$(cat pa11y-exit)
+            if [ "$code" -ne 0 ]; then
+              echo "pa11y failed with exit code $code";
+              exit $code;
+            fi
+          fi

--- a/.github/workflows/html-validate.yml
+++ b/.github/workflows/html-validate.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: |
           echo "Installing project devDependencies (html-validate)"
-          npm ci
+          npm install
 
       - name: Run html-validate
         run: |

--- a/.github/workflows/html-validate.yml
+++ b/.github/workflows/html-validate.yml
@@ -75,6 +75,47 @@ jobs:
           name: pa11y-output
           path: pa11y-output.txt
 
+      - name: Comment on PR with pa11y output
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const path = 'pa11y-output.txt';
+            let output = '';
+            try {
+              if (fs.existsSync(path)) {
+                output = fs.readFileSync(path, 'utf8');
+              } else {
+                output = 'No pa11y output file found.';
+              }
+            } catch (err) {
+              output = `Error reading pa11y output: ${err.message}`;
+            }
+
+            const exitPath = 'pa11y-exit';
+            let exitCode = 'unknown';
+            try {
+              if (fs.existsSync(exitPath)) exitCode = fs.readFileSync(exitPath, 'utf8').trim();
+            } catch (e) {}
+
+            const pr = context.payload.pull_request;
+            if (!pr) {
+              core.info('Not a pull_request event; skipping pa11y PR comment.');
+              return;
+            }
+
+            const issue_number = pr.number;
+            const body = `### pa11y accessibility scan\n\nExit code: ${exitCode}\n\n<details><summary>pa11y output</summary>\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\` + '```\n' + (output.length > 60000 ? output.slice(0,60000) + '\n\n...truncated...' : output) + '\n```\n</details>`;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              body
+            });
+
       - name: Fail job when pa11y failed
         if: always()
         run: |

--- a/.github/workflows/html-validate.yml
+++ b/.github/workflows/html-validate.yml
@@ -1,0 +1,28 @@
+name: HTML Validate (PR)
+
+on:
+  pull_request:
+    paths:
+      - '**/*.html'
+      - 'jim-viewer.html'
+      - 'examples/**'
+      - '.github/workflows/**'
+
+jobs:
+  html-validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Run html-validate (via npx)
+        run: |
+          echo "Running html-validate via npx..."
+          npx --yes html-validate --version
+          # Validate the viewer and HTML files in examples
+          npx --yes html-validate "jim-viewer.html" "**/*.html" || (echo "html-validate reported errors" && exit 1)

--- a/.github/workflows/html-validate.yml
+++ b/.github/workflows/html-validate.yml
@@ -3,9 +3,8 @@ name: HTML Validate (PR)
 on:
   pull_request:
     paths:
-      - '**/*.html'
       - 'jim-viewer.html'
-      - 'examples/**'
+      - 'tests/**'
       - '.github/workflows/**'
 
 jobs:
@@ -32,97 +31,9 @@ jobs:
           # Limit lint targets to project HTML files to avoid scanning node_modules
           npx html-validate "jim-viewer.html" "tests/*.html" || (echo "html-validate reported errors" && exit 1)
 
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const fs = require('fs');
-            const outPath = 'pa11y-output.txt';
-            let output = '';
-            try {
-              output = fs.existsSync(outPath) ? fs.readFileSync(outPath, 'utf8') : 'No pa11y output file found.';
-            } catch (err) {
-              output = 'Error reading pa11y output: ' + (err && err.message ? err.message : String(err));
-            }
-
-            const exitPath = 'pa11y-exit';
-            let exitCode = 'unknown';
-            try { if (fs.existsSync(exitPath)) exitCode = fs.readFileSync(exitPath, 'utf8').trim(); } catch (e) {}
-
-            const pr = context.payload.pull_request;
-            if (!pr) return;
-            const issue_number = pr.number;
-
-            const marker = '<!-- pa11y-bot-comment -->';
-            const runId = process.env.GITHUB_RUN_ID || '';
-            const runUrl = runId ? 'https://github.com/' + context.repo.owner + '/' + context.repo.repo + '/actions/runs/' + runId : '';
-            const runLink = runUrl ? '\n[View full artifacts and logs for this run](' + runUrl + ')\n\n' : '\n';
-            const header = marker + '\n### pa11y accessibility scan\n\nExit code: ' + exitCode + runLink + '\n';
-            const bodyContent = (output.length > 60000 ? output.slice(0,60000) + '\n\n...truncated...' : output);
-            const fullBody = header + '<details><summary>pa11y output</summary>\n\n```text\n' + bodyContent + '\n```\n</details>';
-
-            // List existing comments on the PR and update the bot comment if present
-            const { data: comments } = await github.rest.issues.listComments({ owner: context.repo.owner, repo: context.repo.repo, issue_number });
-            const existing = comments.find(c => c.body && c.body.startsWith(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({ owner: context.repo.owner, repo: context.repo.repo, comment_id: existing.id, body: fullBody });
-            } else {
-              await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number, body: fullBody });
-            }
-          echo "$PA11Y_EXIT" > pa11y-exit
-          set -e
-
-          # Stop the server we started
-          kill $SERVER_PID || true
-
-      - name: Upload pa11y output
+      - name: Upload html-validate output
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: pa11y-output
-          path: pa11y-output.txt
-
-      - name: Comment on PR with pa11y output (update existing bot comment)
-        if: always() && github.event_name == 'pull_request'
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const fs = require('fs');
-            const outPath = 'pa11y-output.txt';
-            let output = '';
-            try { output = fs.existsSync(outPath) ? fs.readFileSync(outPath, 'utf8') : 'No pa11y output file found.'; } catch (err) { output = `Error reading pa11y output: ${err.message}`; }
-            const exitPath = 'pa11y-exit';
-            let exitCode = 'unknown';
-            try { if (fs.existsSync(exitPath)) exitCode = fs.readFileSync(exitPath, 'utf8').trim(); } catch (e) {}
-
-            const pr = context.payload.pull_request;
-            if (!pr) return;
-            const issue_number = pr.number;
-
-            const marker = '<!-- pa11y-bot-comment -->';
-            const runId = process.env.GITHUB_RUN_ID || '';
-            const runUrl = runId ? `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${runId}` : '';
-            const runLink = runUrl ? `\n[View full artifacts and logs for this run](${runUrl})\n\n` : '\n';
-            const header = `${marker}\n### pa11y accessibility scan\n\nExit code: ${exitCode}${runLink}\n`;
-            const bodyContent = (output.length > 60000 ? output.slice(0,60000) + '\n\n...truncated...' : output);
-            const fullBody = header + `<details><summary>pa11y output</summary>\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\` + '```text\n' + bodyContent + '\n```\n</details>';
-
-            // List existing comments on the PR and update the bot comment if present
-            const { data: comments } = await github.rest.issues.listComments({ owner: context.repo.owner, repo: context.repo.repo, issue_number });
-            const existing = comments.find(c => c.body && c.body.startsWith(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({ owner: context.repo.owner, repo: context.repo.repo, comment_id: existing.id, body: fullBody });
-            } else {
-              await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number, body: fullBody });
-            }
-
-      - name: Fail job when pa11y failed
-        if: always()
-        run: |
-          if [ -f pa11y-exit ]; then
-            code=$(cat pa11y-exit)
-            if [ "$code" -ne 0 ]; then
-              echo "pa11y failed with exit code $code";
-              exit $code;
-            fi
-          fi
+          name: html-validate-report
+          path: .

--- a/.github/workflows/html-validate.yml
+++ b/.github/workflows/html-validate.yml
@@ -32,37 +32,42 @@ jobs:
           # Limit lint targets to project HTML files to avoid scanning node_modules
           npx html-validate "jim-viewer.html" "tests/*.html" || (echo "html-validate reported errors" && exit 1)
 
-  a11y-smoke:
-    name: Accessibility smoke (pa11y)
-    runs-on: ubuntu-latest
-    needs: html-validate
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const outPath = 'pa11y-output.txt';
+            let output = '';
+            try {
+              output = fs.existsSync(outPath) ? fs.readFileSync(outPath, 'utf8') : 'No pa11y output file found.';
+            } catch (err) {
+              output = 'Error reading pa11y output: ' + (err && err.message ? err.message : String(err));
+            }
 
-      - name: Install http-server globally
-        run: |
-          npm install -g http-server
+            const exitPath = 'pa11y-exit';
+            let exitCode = 'unknown';
+            try { if (fs.existsSync(exitPath)) exitCode = fs.readFileSync(exitPath, 'utf8').trim(); } catch (e) {}
 
-      - name: Run pa11y accessibility scan (capture output)
-        id: pa11y
-        run: |
-          # Start a local static server in the background and capture its PID
-          npx http-server -p 8080 &
-          SERVER_PID=$!
-          # give server a moment to start
-          sleep 2
+            const pr = context.payload.pull_request;
+            if (!pr) return;
+            const issue_number = pr.number;
 
-          # Run pa11y and tee output to a file. Capture the exit code so we can upload the output
-          # even if pa11y fails, then explicitly fail the job after uploading.
-          set +e
-          npx --yes pa11y http://127.0.0.1:8080/tests/auto-load.html 2>&1 | tee pa11y-output.txt
-          PA11Y_EXIT=${PIPESTATUS[0]}
+            const marker = '<!-- pa11y-bot-comment -->';
+            const runId = process.env.GITHUB_RUN_ID || '';
+            const runUrl = runId ? 'https://github.com/' + context.repo.owner + '/' + context.repo.repo + '/actions/runs/' + runId : '';
+            const runLink = runUrl ? '\n[View full artifacts and logs for this run](' + runUrl + ')\n\n' : '\n';
+            const header = marker + '\n### pa11y accessibility scan\n\nExit code: ' + exitCode + runLink + '\n';
+            const bodyContent = (output.length > 60000 ? output.slice(0,60000) + '\n\n...truncated...' : output);
+            const fullBody = header + '<details><summary>pa11y output</summary>\n\n```text\n' + bodyContent + '\n```\n</details>';
+
+            // List existing comments on the PR and update the bot comment if present
+            const { data: comments } = await github.rest.issues.listComments({ owner: context.repo.owner, repo: context.repo.repo, issue_number });
+            const existing = comments.find(c => c.body && c.body.startsWith(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner: context.repo.owner, repo: context.repo.repo, comment_id: existing.id, body: fullBody });
+            } else {
+              await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number, body: fullBody });
+            }
           echo "$PA11Y_EXIT" > pa11y-exit
           set -e
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,51 @@
+# Node.js / npm
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+package-lock.json
+
+# Optional npm cache directory
+.npm
+
+# VSCode
+.vscode/
+
+# macOS
+.DS_Store
+
+# Logs
+logs
+*.log
+
+# Build / cache
+.cache/
+.parcel-cache/
+dist/
+
+# Environment files
+.env
+.env.*
+
+# Playwright/Puppeteer browsers
+.playwright/
+.pw/
+
+# Temporary files
+tmp/
+temp/
+
+# OS generated files
+Thumbs.db
+
+# JetBrains
+.idea/
+
+# HTML Validate cache
+.htmlvalidate-cache
+
+# Allow keep files
+!.gitkeep
+
+# Axe output artifacts
+axe-output/

--- a/.htmlvalidate.json
+++ b/.htmlvalidate.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["html-validate:recommended"],
+  "rules": {
+    "doctype-style": "error",
+    "void-style": "error",
+    "prefer-native-element": "warn",
+    "no-inline-style": "warn"
+  }
+}

--- a/.pa11yci
+++ b/.pa11yci
@@ -1,0 +1,13 @@
+{
+  "defaults": {
+    "standard": "WCAG2AA",
+    "timeout": 30000,
+    "headers": {
+      "User-Agent": "pa11y-ci"
+    }
+  },
+  "urls": [
+    "http://127.0.0.1:5500/tests/auto-load.html"
+  ],
+  "ignore": []
+}

--- a/CI.md
+++ b/CI.md
@@ -1,0 +1,57 @@
+# CI / Local Validation Guide
+
+This project includes lightweight continuous-integration checks for HTML validity and accessibility. This document explains how to run them locally and how CI runs them in GitHub Actions.
+
+## What runs in CI
+
+- `html-validate` to lint `jim-viewer.html` and other HTML files.
+- `pa11y` (a11y smoke test) against a small test harness that auto-loads an example SVG: `tests/auto-load.html`.
+
+The CI workflow file is at `.github/workflows/html-validate.yml`.
+
+## Run locally (PowerShell)
+
+1. Install dev dependencies:
+
+```powershell
+npm ci
+```
+
+2. Run the HTML linter:
+
+```powershell
+npm run lint:html
+```
+
+3. Start a static server and run pa11y (option A: separate terminals)
+
+Terminal A:
+
+```powershell
+npx http-server -p 5501
+```
+
+Terminal B:
+
+```powershell
+npx pa11y http://127.0.0.1:5501/tests/auto-load.html
+```
+
+4. Or use a single PowerShell session (background job):
+
+```powershell
+$cwd = (Get-Location).Path
+$job = Start-Job -ScriptBlock { param($p) Set-Location $p; npx http-server -p 5501 } -ArgumentList $cwd
+Start-Sleep -Seconds 1
+npx pa11y http://127.0.0.1:5501/tests/auto-load.html
+Stop-Job $job
+Remove-Job $job
+```
+
+Notes
+
+- If port 5500 is already in use (VS Code Live Server commonly uses 5500), use port 5501 as shown above.
+- The test harness at `tests/auto-load.html` instructs the viewer to load `examples/testimage_0.svg`. You can change the example by editing the harness or opening `jim-viewer.html` directly and using the file upload control.
+- The project includes `.pa11yci` and `.htmlvalidate.json` with conservative defaults to reduce noisy CI failures; change them if you need stricter or looser rules.
+
+If you'd like, I can add a GitHub Action step that uploads pa11y output when the job fails to make debugging PR failures easier.

--- a/CI.md
+++ b/CI.md
@@ -55,3 +55,39 @@ Notes
 - The project includes `.pa11yci` and `.htmlvalidate.json` with conservative defaults to reduce noisy CI failures; change them if you need stricter or looser rules.
 
 If you'd like, I can add a GitHub Action step that uploads pa11y output when the job fails to make debugging PR failures easier.
+
+## Running axe-core locally (examples smoke tests)
+
+We added a small helper script that runs axe-core against each example via Playwright. This is useful as an early smoke test to ensure example SVGs don't introduce accessibility violations.
+
+Prerequisites:
+
+- Install project devDependencies and Playwright browsers:
+
+```powershell
+npm ci
+npx playwright install --with-deps
+```
+
+Run the smoke test (assumes a static server is serving the repo on port 8080):
+
+Terminal A — start a simple server:
+
+```powershell
+npx http-server -p 8080
+```
+
+Terminal B — run the axe smoke runner (writes per-example JSON into `axe-output/`):
+
+```powershell
+node scripts/ci-run-axe.js --base-url=http://127.0.0.1:8080 --out-dir=axe-output --fail-on-violations=true
+```
+
+Notes:
+
+- The script will create an `axe-output/` directory with one JSON file per example (e.g. `axe-testimage_0.svg.json`). Those artifacts are ignored by `.gitignore`.
+- If you prefer the npm shortcut (after installing Playwright):
+
+```powershell
+npm run ci:axe
+```

--- a/CI.md
+++ b/CI.md
@@ -13,8 +13,13 @@ The CI workflow file is at `.github/workflows/html-validate.yml`.
 
 1. Install dev dependencies:
 
+If this repository does not have a lockfile (package-lock.json), use `npm install` instead of `npm ci`.
+
 ```powershell
+# If package-lock.json exists:
 npm ci
+# Otherwise (or on first-time setup):
+npm install
 ```
 
 2. Run the HTML linter:
@@ -62,10 +67,13 @@ We added a small helper script that runs axe-core against each example via Playw
 
 Prerequisites:
 
-- Install project devDependencies and Playwright browsers:
+- Install project devDependencies and Playwright browsers. If you don't have a lockfile, use `npm install`.
 
 ```powershell
+# If package-lock.json exists:
 npm ci
+# Otherwise:
+npm install
 npx playwright install --with-deps
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,11 @@ Thanks for your interest in contributing to the JIM Metadata Viewer! A few quick
 - Run the HTML linter locally:
 
 ```powershell
+# If package-lock.json exists:
 npm ci
+npm run lint:html
+# Otherwise, on first-time setup:
+npm install
 npm run lint:html
 ```
 
@@ -26,7 +30,8 @@ If you'd like to run a lightweight axe smoke test across the example SVGs, insta
 
 ```powershell
 # install dev deps and playwright browsers
-npm ci
+# If a lockfile is present, prefer `npm ci` for reproducible installs; otherwise use `npm install`.
+npm ci || npm install
 npx playwright install --with-deps
 
 # start a local server (port 8080 recommended)
@@ -35,6 +40,8 @@ npx http-server -p 8080
 # run the axe smoke tests (writes outputs to axe-output/)
 node scripts/ci-run-axe.js --base-url=http://127.0.0.1:8080 --out-dir=axe-output --fail-on-violations=true
 ```
+
+Tip: Commit a generated `package-lock.json` to the repository to make CI installs deterministic and allow using `npm ci` in workflows.
 
 The `axe-output/` directory is ignored by `.gitignore` and contains one JSON artifact per example.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# Contributing
+
+Thanks for your interest in contributing to the JIM Metadata Viewer! A few quick guidelines to make contributions easier to review and land.
+
+## Before you open a PR
+
+- Run the HTML linter locally:
+
+```powershell
+npm ci
+npm run lint:html
+```
+
+- Run the accessibility smoke test (recommended) using the test harness:
+
+```powershell
+# start a local server (port 5501 recommended)
+npx http-server -p 5501
+# in another terminal
+npx pa11y http://127.0.0.1:5501/tests/auto-load.html
+```
+
+- See `CI.md` for additional guidance on running checks locally and avoiding common CI issues.
+
+## PR checklist
+
+- [ ] Code compiles and lints (`npm run lint:html`)
+- [ ] New features include accessible markup and keyboard interactions
+- [ ] Add or update tests/examples where relevant
+- [ ] Update `README.md` or `CI.md` if the change affects developer workflows
+
+Thanks — contributions are welcome! If you need help reproducing CI locally, open an issue or drop a note in the PR description.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,24 @@ npx http-server -p 5501
 npx pa11y http://127.0.0.1:5501/tests/auto-load.html
 ```
 
+### Axe smoke tests (optional)
+
+If you'd like to run a lightweight axe smoke test across the example SVGs, install Playwright and run the helper script:
+
+```powershell
+# install dev deps and playwright browsers
+npm ci
+npx playwright install --with-deps
+
+# start a local server (port 8080 recommended)
+npx http-server -p 8080
+
+# run the axe smoke tests (writes outputs to axe-output/)
+node scripts/ci-run-axe.js --base-url=http://127.0.0.1:8080 --out-dir=axe-output --fail-on-violations=true
+```
+
+The `axe-output/` directory is ignored by `.gitignore` and contains one JSON artifact per example.
+
 - See `CI.md` for additional guidance on running checks locally and avoiding common CI issues.
 
 ## PR checklist

--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ An interactive tool for analyzing and validating JSON for Interactive Media (JIM
 	- `Number_of_Xbox_Live_MAU_Q1_2016___Q4_2019.svg`
 	- `Unemployment_rate_in_Greece_1999_2019.svg`
 
+## Running accessibility checks
+
+See `CI.md` for details on the small CI/test helpers. In short:
+
+- The repository runs `html-validate` and a pa11y smoke test in CI.
+- You can run an axe-core smoke test locally across the example SVGs with Playwright using the `scripts/ci-run-axe.js` helper. See `CI.md` for commands and notes.
+
 ## Use Cases
 
 - Validate JIM metadata during development

--- a/jim-viewer.html
+++ b/jim-viewer.html
@@ -393,7 +393,7 @@
             </section>
         </main>
 
-        <aside id="info-panel" class="info-panel" role="region" aria-labelledby="element-info-heading" tabindex="-1">
+    <aside id="info-panel" class="info-panel" aria-labelledby="element-info-heading" tabindex="-1">
             <div class="info-panel-header">
                 <h3 id="element-info-heading">Element Information</h3>
                 <button type="button" class="close-btn" aria-label="Close information panel">&times;</button>

--- a/jim-viewer.html
+++ b/jim-viewer.html
@@ -14,9 +14,9 @@
             --muted-contrast: #334155;
             --metadata-bg: #ffffff;
             --metadata-border: #e6eef6;
-            --status-error: #9b1c1c;
-            --status-warning: #7c2d12;
-            --status-success: #022f26;
+            --status-error: #dc2626; /* brighter red (Tailwind red-600) */
+            --status-warning: #b45309; /* brighter orange (Tailwind amber-600) */
+            --status-success: #065f46; /* darker emerald green for WCAG contrast */
             --badge-bg-jim: #047857;
             --badge-bg-nojim: #334155;
             /* High-contrast link color for small inline controls */
@@ -31,6 +31,19 @@
         .status-success-line { color: var(--status-success); margin:4px 0; font-weight:600; }
         .status-warning-line { color: var(--status-warning); margin:4px 0; }
         .status-error-line { color: var(--status-error); margin:4px 0; }
+        /* Status icons (use symbol fonts to avoid color-emoji rendering so axe can compute contrast) */
+        .status-icon {
+            font-family: "Segoe UI Symbol", "Segoe UI", "Arial", sans-serif;
+            font-weight: 700;
+            line-height: 1;
+            display: inline-block;
+            vertical-align: middle;
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
+            /* ensure color is inherited from the status line (do not set a separate color) */
+            color: inherit;
+            margin-right: 6px;
+        }
             /* Spec compliance box variants (used in metadata summary) */
             .spec-box { padding: 12px 16px; border-radius: 6px; margin-bottom: 16px; }
             .spec-box--error { background: #fee2e2; border: 1px solid #dc2626; }
@@ -58,20 +71,28 @@
                 .btn--selector--mapped { background: #d1fae5; border-color: #10b981; color: #022f26; }
                 .btn--selector--group { background: #fef9c3; border-color: #f59e0b; color: #92400e; }
                 .selector-panel { background: #f8fafc; border:1px solid #e2e8f0; border-radius:6px; padding:12px 16px; margin-bottom:8px; }
-                .selector-row { display:flex; flex-wrap:wrap; gap:8px; margin-top:8px; }
+                .selector-row { display:flex; flex-wrap:wrap; gap:8px; margin-top:8px; margin-bottom:12px; }
+                /* Main selector panel title (larger) vs subgroup headings (smaller) */
+                .selector-panel > h2.panel__heading { font-size: 18px; margin-top: 0; margin-bottom: 10px; }
+                /* Ensure subgroup headings inside selector panels have breathing room */
+                .selector-panel .panel__heading { margin-top:12px; margin-bottom:8px; font-size:14px; }
                 .badge { padding:2px 6px; border-radius:3px; font-size:11px; display:inline-block; vertical-align:middle; margin-left:4px; color: #fff; }
                 .badge--jim { background: var(--badge-bg-jim); }
                 .badge--nojim { background: var(--badge-bg-nojim); }
                 .snippet { background:#f8fafc; padding:8px; border-radius:4px; margin-top:6px; max-height:120px; overflow:auto; }
                 .snippet--error { background:#fff0f0; color:var(--status-error); }
                 .muted-note { color: var(--muted-contrast); font-size:13px; margin-top:8px; }
-                .computed-dot { display:inline-block; width:12px; height:12px; border-radius:50%; margin-right:6px; vertical-align:middle; }
+                .computed-dot { display:inline-block; width:10px; height:10px; border-radius:50%; margin-right:6px; vertical-align:middle; }
+            .computed-dot-wrap { display:inline-flex; align-items:center; justify-content:center; width:16px; height:16px; border-radius:8px; margin-right:8px; vertical-align:middle; overflow:visible; }
+            .computed-dot-swatch { width:10px; height:10px; border-radius:50%; display:block; box-shadow: inset 0 0 0 1px rgba(0,0,0,0.06); }
+            .nojim-note { margin-top:8px; color:#334155; font-size:13px; }
         /* Orphaned selector card and meta text */
         .orphaned-item { background:#eff6ff; border-left:3px solid #3b82f6; padding:8px; margin:8px 0; border-radius:4px; font-size:13px; color:#1e293b; }
         .meta-text { color:#334155; font-size:12px; }
     /* Additional utility classes for consolidated inline styles */
     .hidden { display: none !important; }
-    .section-heading { margin-top: 16px; margin-bottom: 8px; font-size:16px; color: #1f2937; }
+    /* Section headings inside metadata panels: add a little more breathing room and subtle padding */
+    .section-heading { margin-top: 22px; margin-bottom: 10px; padding-top: 6px; font-size:16px; color: #1f2937; }
     .wrap-chips { display:flex; flex-wrap:wrap; gap:8px; margin-bottom:8px; }
     .inline-row { display:inline-flex; align-items:center; }
     .inline-code { color:var(--text-normal); }
@@ -137,6 +158,7 @@
 
         .file-input-wrapper {
             margin-bottom: 15px;
+            display: block;
         }
 
         .file-input-wrapper label {
@@ -152,7 +174,21 @@
             border: 2px dashed #cbd5e1;
             border-radius: 6px;
             cursor: pointer;
+            background: white;
         }
+
+        /* Layout row next to file input to show the current file (hides browser's default filename text) */
+    .file-input-row { display: flex; align-items: center; gap: 12px; }
+        /* Some browsers insert a pseudo-element showing the chosen file; hide that where possible */
+        input[type='file']::-webkit-file-upload-text { display: none; }
+        input[type='file']::-webkit-file-upload-button { display: inline-block; }
+        input[type='file']::file-selector-button { display: inline-block; }
+    #current-file { font-size: 13px; color: #475569; }
+
+    /* Use the browser's native file input so freeform typing and native behaviors are preserved */
+    input[type="file"] { display: inline-block; }
+    .file-input-row { display: flex; align-items: center; gap: 12px; }
+    #current-file { font-size: 13px; color: #475569; user-select: text; max-width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
         input[type="file"]:hover {
             border-color: #3b82f6;
@@ -168,6 +204,19 @@
             color: #64748b;
             margin-top: 5px;
         }
+
+        /* Default current-file styling (used outside chooser if present) */
+        #current-file {
+            font-size: 13px;
+            color: #475569;
+            max-width: 100%;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+        /* Make the chooser full width and render filename inline next to the button */
+        .file-chooser { width: 100%; box-sizing: border-box; }
+    .file-chooser #current-file { display: inline-flex; align-items: center; margin-top: 0; max-width: calc(100% - 140px); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; padding-left:6px; }
 
         .viewer-section {
             background: white;
@@ -217,7 +266,7 @@
             border: none;
             font-size: 20px;
             cursor: pointer;
-            color: #94a3b8;
+            color: #1e293b; /* darker for measurable contrast */
             padding: 0;
             width: 24px;
             height: 24px;
@@ -313,12 +362,34 @@
         }
 
         .metadata-summary {
-            background: var(--metadata-bg); /* lighten to improve contrast for status text */
-            border: 1px solid var(--metadata-border); /* subtle cool border for separation */
+            /* Faint panel background to match the selectors box */
+            background: #f8fafc; /* same as .selector-panel */
+            border: 1px solid #e2e8f0; /* subtle cool border for separation */
             border-radius: 6px;
             padding: 16px;
             margin-bottom: 20px;
             color: var(--text-normal);
+        }
+
+        /* Tighter visual separation and improved readability for the validation block */
+        .metadata-summary .section-heading {
+            border-top: 1px solid var(--metadata-border);
+            padding-top: 8px;
+            margin-top: 14px;
+            margin-bottom: 8px;
+            color: #0f172a; /* slightly darker for emphasis */
+            font-weight: 700;
+        }
+
+        /* Make long validation lines easier to scan and wrap long comma-separated lists */
+        .metadata-summary .status-warning-line,
+        .metadata-summary .status-success-line,
+        .metadata-summary .status-error-line,
+        .metadata-summary .muted-note {
+            line-height: 1.6;
+            margin-top: 6px;
+            white-space: normal;
+            word-break: break-word;
         }
 
         .metadata-summary h3 {
@@ -353,6 +424,16 @@
             margin: 16px 0;
         }
     </style>
+    <script>
+        // Small inline SVG icons (fill uses currentColor so they inherit text color)
+        const ICONS = {
+            check: `<svg class="status-icon" width="14" height="14" viewBox="0 0 24 24" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"/></svg>`,
+            cross: `<svg class="status-icon" width="14" height="14" viewBox="0 0 24 24" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/></svg>`,
+            warn: `<svg class="status-icon" width="14" height="14" viewBox="0 0 24 24" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"/></svg>`,
+            idea: `<svg class="status-icon" width="14" height="14" viewBox="0 0 24 24" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="M9 21h6v-1H9v1zm3-19C8.48 2 5 5.48 5 9c0 2.5 1.5 4.66 3.79 5.5.21.09.36.29.36.52V17h6V15.02c0-.23.15-.43.36-.52C17.5 13.66 19 11.5 19 9c0-3.52-3.48-7-7-7z"/></svg>`,
+            group: `<svg class="status-icon" width="14" height="14" viewBox="0 0 24 24" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="M16 11c1.66 0 2.99-1.34 2.99-3S17.66 5 16 5s-3 1.34-3 3 1.34 3 3 3zM8 11c1.66 0 2.99-1.34 2.99-3S9.66 5 8 5 5 6.34 5 8s1.34 3 3 3zm0 2c-2.33 0-7 1.17-7 3.5V19h14v-2.5C15 14.17 10.33 13 8 13zm8 0c-.29 0-.62.02-.97.05C16.22 13.78 18 14.84 18 16v3h6v-2.5C24 14.17 19.33 13 16 13z"/></svg>`
+        };
+    </script>
 </head>
 <body>
     <a href="#main-content" class="skip-link">Skip to main content</a>
@@ -371,7 +452,10 @@
                 <h2 id="upload-heading" class="sr-only">File Upload</h2>
                 <div class="file-input-wrapper">
                     <label for="jim-file">Upload SVG or HTML file:</label>
-                    <input type="file" id="jim-file" accept=".svg,.html,.htm" aria-describedby="file-help">
+                    <div class="file-input-row">
+                        <input type="file" id="jim-file" accept=".svg,.html,.htm" aria-describedby="file-help">
+                        <span id="current-file" class="sr-only" aria-live="polite">No file loaded</span>
+                    </div>
                     <div id="file-help" class="file-help">Supported: SVG files (with or without JIM metadata) and HTML files containing SVG elements.</div>
                 </div>
                 <div id="metadata-summary" aria-live="polite"></div>
@@ -381,7 +465,7 @@
             <section id="selector-list-panel" class="selector-panel hidden"></section>
             <section class="viewer-section" aria-labelledby="visualization-heading">
                 <h2 id="visualization-heading">Interactive Visualization</h2>
-                <div id="visualization" aria-live="polite" aria-labelledby="visualization-heading">
+                <div id="visualization" aria-live="polite" tabindex="0">
                     <div class="empty-state">
                         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
                             <path d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
@@ -1129,6 +1213,25 @@
                 if (fileInput) {
                     fileInput.addEventListener('change', async (e) => {
                         const file = e.target.files && e.target.files[0];
+                        const row = e.target.closest && e.target.closest('.file-input-row');
+                        try {
+                            // Use the shared helper so local file selection and autoload behave the same
+                            if (file) {
+                                if (typeof setCurrentFileLabel === 'function') setCurrentFileLabel(file.name || 'Local file');
+                                else {
+                                    const label = document.getElementById('current-file');
+                                    if (label) label.textContent = file.name || 'Local file';
+                                }
+                                // Hide the duplicate visible filename when the native input already shows one.
+                                if (row) row.classList.add('has-file');
+                                const cur = document.getElementById('current-file');
+                                if (cur) cur.classList.add('sr-only');
+                            } else {
+                                // No file selected: remove the 'has-file' state. Keep the accessible-only label hidden by default.
+                                if (row) row.classList.remove('has-file');
+                            }
+                        } catch (e) { /* ignore */ }
+
                         if (!file) return;
                         const ext = file.name.split('.').pop().toLowerCase();
                         const reader = new FileReader();
@@ -1260,7 +1363,7 @@
                             snippet = jimText.slice(Math.max(0, pos-40), pos+40);
                         }
                         let errorHtml = `<div class="error-box">` +
-                            `<strong class="error-text"><span class="sr-only">Error: </span><span aria-hidden="true" class="status-icon">✗</span> Invalid JIM JSON in file${lineInfo}</strong><br>` +
+                            `<strong class="error-text"><span class="sr-only">Error: </span>${ICONS.cross} Invalid JIM JSON in file${lineInfo}</strong><br>` +
                             `<div class='muted-note' style='color:var(--status-error);'>${e.message}</div>` +
                             (snippet ? `<pre class='snippet snippet--error'>${snippet.replace(/</g,'&lt;').replace(/>/g,'&gt;')}</pre>` : '') +
                             `<div class='muted-note'>Tip: Check for missing commas, brackets, or invalid array/object usage. You can copy and validate this JSON at <a href='https://jsonlint.com/' target='_blank' style='color:#2563eb;'>jsonlint.com</a>.</div>` +
@@ -1273,7 +1376,7 @@
                 } else {
                     console.warn('[JIMViewer] No JIM metadata found in file.');
                     const errorHtml = `<div class="error-box">` +
-                        `<strong class="error-text"><span class="sr-only">Error: </span><span aria-hidden="true" class="status-icon">✗</span> No JIM metadata found in file</strong><br>` +
+                        `<strong class="error-text"><span class="sr-only">Error: </span>${ICONS.cross} No JIM metadata found in file</strong><br>` +
                         `<div class='muted-note' style='color:var(--status-error);'>JIM metadata must be in a &lt;script type="application/json+jim"&gt; or &lt;metadata data-type="text/jim+json"&gt; block.</div>` +
                         `<div class='muted-note'>Tip: Check your SVG for a valid JIM metadata block.</div>` +
                         `</div>`;
@@ -1315,7 +1418,7 @@
                     var behaviors = this.jimData.behaviors || [];
                     var selectorPanelHtml = "<div class='selector-panel'>";
                     selectorPanelHtml += "<h2 class='panel__heading'>Selectors</h2>";
-                    selectorPanelHtml += "<div class='selector-row'>";
+                    
                     var svg = this.currentDoc.querySelector('svg');
                     // Track group behaviors
                     var groupBehaviors = [];
@@ -1329,6 +1432,10 @@
                             }
                         }
                     }
+                    // Build a list of visible selectors (those that match at least one SVG element),
+                    // annotate them with mapping state, then sort: mapped first, group-mapped second,
+                    // unmapped last. Within each bucket sort alphabetically by selector key.
+                    var visibleSelectors = [];
                     for (var k = 0; k < selectorKeys.length; k++) {
                         var key = selectorKeys[k];
                         var dom = this.jimData.selectors[key].dom;
@@ -1336,7 +1443,7 @@
                         var isGroupMapped = false;
                         var A = [];
                         try { A = Array.from(svg.querySelectorAll(dom)); } catch (e) {}
-                        // Only show selectors that match at least one SVG element
+                        // Only include selectors that match at least one SVG element
                         if (!A.length) continue;
                         for (var j = 0; j < behaviors.length; j++) {
                             var tgtSelector = behaviors[j].target && behaviors[j].target.selector;
@@ -1346,21 +1453,54 @@
                                 // Direct mapping: selector's dom exactly matches behavior's selector
                                 if (dom === tgtSelector) { hasBehavior = true; break; }
                                 // If not direct, but covered by a group behavior
-                                if (!hasBehavior && B.length > 1 && B.some(b => A.includes(b))) {
+                                if (!hasBehavior && B.length > 1 && B.some(function(b){ return A.includes(b); })) {
                                     isGroupMapped = true;
                                 }
                             }
                         }
-                        var cls = 'btn selector-button';
-                        if (hasBehavior) cls += ' btn--selector--mapped';
-                        else if (isGroupMapped) cls += ' btn--selector--group';
-                        else cls += ' btn--selector';
-                        var icon = hasBehavior ? "<span class='sr-only'>Mapped: </span><span style='margin-right:4px;' aria-hidden='true' class='status-icon'>✓</span>" : (isGroupMapped ? "<span class='sr-only'>Group: </span><span style='margin-right:4px;' aria-hidden='true' class='status-icon'>👥</span>" : "");
-                        var ariaState = hasBehavior ? ', mapped' : (isGroupMapped ? ', group mapped' : ', not mapped');
-                        var ariaLabel = `Selector ${key}${ariaState}`;
-                        selectorPanelHtml += `<button class='${cls} selector-button' data-key='${key}' aria-label='${ariaLabel}'>${icon}${key}</button>`;
+                        visibleSelectors.push({ key: key, dom: dom, hasBehavior: hasBehavior, isGroupMapped: isGroupMapped });
                     }
-                    selectorPanelHtml += "</div>";
+
+                    // Sorting helper: rank mapped=0, group=1, unmapped=2
+                    function selRank(s) { return s.hasBehavior ? 0 : (s.isGroupMapped ? 1 : 2); }
+                    visibleSelectors.sort(function(a, b) {
+                        var ra = selRank(a), rb = selRank(b);
+                        if (ra !== rb) return ra - rb;
+                        // Natural (numeric-aware) alphabetical fallback so 'datapoint2' sorts before 'datapoint10'
+                        return a.key.localeCompare(b.key, undefined, { numeric: true, sensitivity: 'base' });
+                    });
+
+                    // Partition into buckets for clearer traversal
+                    var mapped = visibleSelectors.filter(function(s){ return s.hasBehavior; });
+                    var groupMapped = visibleSelectors.filter(function(s){ return !s.hasBehavior && s.isGroupMapped; });
+                    var unmapped = visibleSelectors.filter(function(s){ return !s.hasBehavior && !s.isGroupMapped; });
+
+                    // Helper to render a bucket with a heading
+                    function renderBucket(title, items, extraClass) {
+                        if (!items || !items.length) return '';
+                        var out = `<h3 class='panel__heading'>${title} (${items.length})</h3>`;
+                        out += "<div class='selector-row'>";
+                        for (var ii = 0; ii < items.length; ii++) {
+                            var sel = items[ii];
+                            var key = sel.key;
+                            var hasBehavior = sel.hasBehavior;
+                            var isGroupMapped = sel.isGroupMapped;
+                            var cls = 'btn selector-button';
+                            if (hasBehavior) cls += ' btn--selector--mapped';
+                            else if (isGroupMapped) cls += ' btn--selector--group';
+                            else cls += ' btn--selector';
+                            var icon = hasBehavior ? "<span class='sr-only'>Mapped: </span>" + ICONS.check : (isGroupMapped ? "<span class='sr-only'>Group: </span>" + ICONS.group : "");
+                            var ariaState = hasBehavior ? ', mapped' : (isGroupMapped ? ', group mapped' : ', not mapped');
+                            var ariaLabel = `Selector ${key}${ariaState}`;
+                            out += `<button class='${cls} selector-button' data-key='${key}' aria-label='${ariaLabel}'>${icon}${key}</button>`;
+                        }
+                        out += "</div>";
+                        return out;
+                    }
+
+                    selectorPanelHtml += renderBucket('Mapped Selectors', mapped);
+                    selectorPanelHtml += renderBucket('Group-mapped Selectors', groupMapped);
+                    selectorPanelHtml += renderBucket('Unmapped Selectors', unmapped);
                     // Add group behaviors section
                     if (groupBehaviors.length) {
                         // Build interactive group behavior controls: header button + member preview buttons
@@ -1405,15 +1545,15 @@
                                                                         specBox = `<div class="spec-box spec-box--${variant}">
                                                                             <strong class="spec-box-heading">Spec compliance</strong>
                                                                             <ul class="spec-box-list">
-                                                                                ${this.specIssues.errors.map(e=>`<li class="status-error-line"><span class="sr-only">Error: </span><span aria-hidden="true" class="status-icon">✗</span> ${e}</li>`).join('')}
-                                                                                ${this.specIssues.warnings.map(w=>`<li class="status-warning-line"><span class="sr-only">Warning: </span><span aria-hidden="true" class="status-icon">⚠</span> ${w}</li>`).join('')}
+                                                ${this.specIssues.errors.map(e=>`<li class="status-error-line"><span class="sr-only">Error: </span>${ICONS.cross} ${e}</li>`).join('')}
+                                                ${this.specIssues.warnings.map(w=>`<li class="status-warning-line"><span class="sr-only">Warning: </span>${ICONS.warn} ${w}</li>`).join('')}
                                                                             </ul>
                                                                             ${this.specIssues.fixes.length ? `<div class="spec-box-fixes">Normalizations: ${this.specIssues.fixes.join(', ')}</div>` : ''}
                                                                         </div>`;
                                                                     } else {
                                                                         // No errors or warnings: show green success box
                                                                         specBox = `<div class="spec-box spec-box--success">
-                                                                            <strong class="spec-box-heading"><span class="sr-only">Success: </span><span aria-hidden="true" class="status-icon">✓</span> No JIM issues found</strong>
+                                                                            <strong class="spec-box-heading"><span class="sr-only">Success: </span>${ICONS.check} No JIM issues found</strong>
                                                                         </div>`;
                                                                     }
                                                                 }
@@ -1522,8 +1662,47 @@
             if (window.getComputedStyle) {
                 const computed = window.getComputedStyle(element);
                 html += '<h4 class="spec-heading">Computed Styles</h4>';
-                html += `<div><strong>fill:</strong> <span style="color: ${computed.fill};">●</span> ${computed.fill}</div>`;
-                html += `<div><strong>stroke:</strong> <span style="color: ${computed.stroke};">●</span> ${computed.stroke}</div>`;
+
+                // Small helper: parse rgb/#hex into [r,g,b]
+                function parseRgbLocal(str) {
+                    if (!str) return null;
+                    str = String(str).trim();
+                    let m;
+                    if (str.startsWith('rgb')) {
+                        m = str.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/i);
+                        if (m) return [parseInt(m[1],10), parseInt(m[2],10), parseInt(m[3],10)];
+                    }
+                    if (str[0] === '#') {
+                        const hex = str.slice(1);
+                        if (hex.length === 3) return [parseInt(hex[0]+hex[0],16), parseInt(hex[1]+hex[1],16), parseInt(hex[2]+hex[2],16)];
+                        if (hex.length === 6) return [parseInt(hex.slice(0,2),16), parseInt(hex.slice(2,4),16), parseInt(hex.slice(4,6),16)];
+                    }
+                    return null;
+                }
+
+                function relLumLocal([r,g,b]){
+                    const srgb = [r,g,b].map(v => v/255).map(c => c <= 0.03928 ? c/12.92 : Math.pow((c+0.055)/1.055, 2.4));
+                    return 0.2126*srgb[0] + 0.7152*srgb[1] + 0.0722*srgb[2];
+                }
+
+                function contrastLocal(a,b){ const L1 = relLumLocal(a); const L2 = relLumLocal(b); const light = Math.max(L1,L2); const dark = Math.min(L1,L2); return (light + 0.05) / (dark + 0.05); }
+
+                function chooseBlackOrWhiteFor(colorStr) {
+                    const rgb = parseRgbLocal(colorStr);
+                    if (!rgb) return '#ffffff'; // default to white when unknown
+                    const whiteContrast = contrastLocal(rgb, [255,255,255]);
+                    const blackContrast = contrastLocal(rgb, [0,0,0]);
+                    return (whiteContrast >= blackContrast) ? '#ffffff' : '#000000';
+                }
+
+                // Render fill + stroke with deterministic background (white or black)
+                const fillStr = computed.fill || 'none';
+                const strokeStr = computed.stroke || 'none';
+                const fillBg = chooseBlackOrWhiteFor(fillStr);
+                const strokeBg = chooseBlackOrWhiteFor(strokeStr);
+
+                html += `<div><strong>fill:</strong> <span class="computed-dot-wrap" style="background:${fillBg};"><span aria-hidden="true" class="computed-dot-swatch" style="background:${fillStr};"></span></span> ${fillStr}</div>`;
+                html += `<div><strong>stroke:</strong> <span class="computed-dot-wrap" style="background:${strokeBg};"><span aria-hidden="true" class="computed-dot-swatch" style="background:${strokeStr};"></span></span> ${strokeStr}</div>`;
                 html += `<div><strong>stroke-width:</strong> ${computed.strokeWidth}</div>`;
                 html += `<div><strong>opacity:</strong> ${computed.opacity}</div>`;
                 html += `<div><strong>display:</strong> ${computed.display}</div>`;
@@ -1535,13 +1714,14 @@
                     html += `<div><strong>font-weight:</strong> ${computed.fontWeight}</div>`;
                     const textContent = element.textContent.trim();
                     if (textContent) {
-                        html += `<div class="inline-text"><strong>Text Content:</strong> "${textContent}"</div>`;
+                        html += `<div class="inline-text"><strong>Text Content:</strong> \"${textContent}\"</div>`;
                     }
                 }
             }
 
-            html += `<div style=\"margin-top:8px;color:#888;font-size:13px;\">No JIM selector defined for this element.</div>`;
+            html += `<div class="nojim-note">No JIM selector defined for this element.</div>`;
             this.infoContent.innerHTML = html;
+            try { if (window.enhanceComputedDots) window.enhanceComputedDots(this.infoContent); } catch (e) { /* ignore */ }
             this.infoPanel.classList.add('visible');
             // Update the live region for SR users after the panel is visible (one-frame delay)
             const liveRegion = document.getElementById('info-panel-live');
@@ -1628,6 +1808,7 @@
             }
 
             this.infoContent.innerHTML = html;
+            try { if (window.enhanceComputedDots) window.enhanceComputedDots(this.infoContent); } catch (e) { /* ignore */ }
             this.infoPanel.classList.add('visible');
 
             // Update live region
@@ -1692,9 +1873,9 @@
         }
         renderValidationSummary(validation) {
             let html = '';
-            validation.errors.forEach(err => { html += `<div class="status-error-line"><span class="sr-only">Error: </span><span aria-hidden="true" class="status-icon">✗</span> ${err}</div>`; });
-            validation.warnings.forEach(w => { html += `<div class="status-warning-line"><span class="sr-only">Warning: </span><span aria-hidden="true" class="status-icon">⚠</span> ${w}</div>`; });
-            validation.passed.forEach(p => { html += `<div class="status-success-line"><span class="sr-only">Success: </span><span aria-hidden="true" class="status-icon">✓</span> ${p}</div>`; });
+            validation.errors.forEach(err => { html += `<div class="status-error-line"><span class="sr-only">Error: </span>${ICONS.cross} ${err}</div>`; });
+            validation.warnings.forEach(w => { html += `<div class="status-warning-line"><span class="sr-only">Warning: </span>${ICONS.warn} ${w}</div>`; });
+            validation.passed.forEach(p => { html += `<div class="status-success-line"><span class="sr-only">Success: </span>${ICONS.check} ${p}</div>`; });
 
             if (validation.orphanedSelectors?.length) {
                 html += `<div class='spec-heading' style='margin-top:12px; padding-top:12px; border-top:1px solid var(--metadata-border);'><strong>Orphaned Selectors (not in DOM):</strong></div>`;
@@ -1753,7 +1934,7 @@
                             <div class="inline-row"><code class="inline-code">${item.selector}</code>${jimBadge}</div>
                             ${item.textContent ? `<div class="inline-text">Text: \"${item.textContent}\"</div>` : ''}
                             <!-- Accessibility attributes removed from visual output -->
-                                            ${item.suggestions?.length ? `<div class="muted-note"><span class="sr-only">Suggestion: </span><span aria-hidden="true" class="status-icon">💡</span> ${item.suggestions.join('; ')}</div>` : ''}
+                                            ${item.suggestions?.length ? `<div class="muted-note"><span class="sr-only">Suggestion: </span>${ICONS.idea} ${item.suggestions.join('; ')}</div>` : ''}
                         </button>`;
                 });
 
@@ -1814,13 +1995,13 @@
                 });
 
                 let html = '';
-                html += `<div class="status-success-line"><span class="sr-only">Success: </span><span aria-hidden="true" class="status-icon">✓</span> Found ${interactiveCount} interactive elements</div>`;
-                html += `<div class="status-success-line"><span class="sr-only">Success: </span><span aria-hidden="true" class="status-icon">✓</span> Found ${textCount} text elements</div>`;
-                html += `<div class="status-success-line"><span class="sr-only">Success: </span><span aria-hidden="true" class="status-icon">✓</span> ${accessibleCount} elements have accessibility labels</div>`;
+                html += `<div class="status-success-line"><span class="sr-only">Success: </span>${ICONS.check} Found ${interactiveCount} interactive elements</div>`;
+                html += `<div class="status-success-line"><span class="sr-only">Success: </span>${ICONS.check} Found ${textCount} text elements</div>`;
+                html += `<div class="status-success-line"><span class="sr-only">Success: </span>${ICONS.check} ${accessibleCount} elements have accessibility labels</div>`;
 
                 if (issues.length > 0) {
                     issues.slice(0, 3).forEach(issue => {
-                        html += `<div class="status-warning-line"><span class="sr-only">Warning: </span><span aria-hidden="true" class="status-icon">⚠</span> ${issue}</div>`;
+                        html += `<div class="status-warning-line"><span class="sr-only">Warning: </span>${ICONS.warn} ${issue}</div>`;
                     });
                     if (issues.length > 3) {
                         html += `<div class="muted-note italic">... and ${issues.length - 3} more issues</div>`;
@@ -2048,8 +2229,46 @@
         if (window.getComputedStyle && vizElement) {
             const computed = window.getComputedStyle(vizElement);
             html += '<h4 class="spec-heading">Computed Styles</h4>';
-            html += `<div><strong>fill:</strong> <span style="color: ${computed.fill};">●</span> ${computed.fill}</div>`;
-            html += `<div><strong>stroke:</strong> <span style="color: ${computed.stroke};">●</span> ${computed.stroke}</div>`;
+
+            // Local helpers to pick white or black neutral background for a color string
+            function parseRgbLocal(str) {
+                if (!str) return null;
+                str = String(str).trim();
+                let m;
+                if (str.startsWith('rgb')) {
+                    m = str.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/i);
+                    if (m) return [parseInt(m[1],10), parseInt(m[2],10), parseInt(m[3],10)];
+                }
+                if (str[0] === '#') {
+                    const hex = str.slice(1);
+                    if (hex.length === 3) return [parseInt(hex[0]+hex[0],16), parseInt(hex[1]+hex[1],16), parseInt(hex[2]+hex[2],16)];
+                    if (hex.length === 6) return [parseInt(hex.slice(0,2),16), parseInt(hex.slice(2,4),16), parseInt(hex.slice(4,6),16)];
+                }
+                return null;
+            }
+
+            function relLumLocal([r,g,b]){
+                const srgb = [r,g,b].map(v => v/255).map(c => c <= 0.03928 ? c/12.92 : Math.pow((c+0.055)/1.055, 2.4));
+                return 0.2126*srgb[0] + 0.7152*srgb[1] + 0.0722*srgb[2];
+            }
+
+            function contrastLocal(a,b){ const L1 = relLumLocal(a); const L2 = relLumLocal(b); const light = Math.max(L1,L2); const dark = Math.min(L1,L2); return (light + 0.05) / (dark + 0.05); }
+
+            function chooseBlackOrWhiteFor(colorStr) {
+                const rgb = parseRgbLocal(colorStr);
+                if (!rgb) return '#ffffff';
+                const whiteContrast = contrastLocal(rgb, [255,255,255]);
+                const blackContrast = contrastLocal(rgb, [0,0,0]);
+                return (whiteContrast >= blackContrast) ? '#ffffff' : '#000000';
+            }
+
+            const fillStr = computed.fill || 'none';
+            const strokeStr = computed.stroke || 'none';
+            const fillBg = chooseBlackOrWhiteFor(fillStr);
+            const strokeBg = chooseBlackOrWhiteFor(strokeStr);
+
+                html += `<div><strong>fill:</strong> <span class="computed-dot-wrap" style="background:${fillBg};"><span aria-hidden="true" class="computed-dot-swatch" style="background:${fillStr};"></span></span> ${fillStr}</div>`;
+                html += `<div><strong>stroke:</strong> <span class="computed-dot-wrap" style="background:${strokeBg};"><span aria-hidden="true" class="computed-dot-swatch" style="background:${strokeStr};"></span></span> ${strokeStr}</div>`;
             html += `<div><strong>stroke-width:</strong> ${computed.strokeWidth}</div>`;
             html += `<div><strong>opacity:</strong> ${computed.opacity}</div>`;
             html += `<div><strong>display:</strong> ${computed.display}</div>`;
@@ -2066,7 +2285,8 @@
             }
         }
 
-        this.infoContent.innerHTML = html;
+    this.infoContent.innerHTML = html;
+    try { if (window.enhanceComputedDots) window.enhanceComputedDots(this.infoContent); } catch (e) { /* ignore */ }
         this.infoPanel.classList.add('visible');
         // Update the live region for SR users after the panel is visible (one-frame delay)
         const liveRegion = document.getElementById('info-panel-live');
@@ -2152,37 +2372,37 @@
                 // Facet validation
                     if (validation.facetSummary) {
                         if (validation.facetSummary.missing && validation.facetSummary.missing.length) {
-                            html += `<div class="status-warning-line"><span class="sr-only">Warning: </span><span aria-hidden="true" class="status-icon">⚠</span> ${validation.facetSummary.missing.length} record properties lack facet definitions: ${validation.facetSummary.missing.join(', ')}</div>`;
+                            html += `<div class="status-warning-line"><span class="sr-only">Warning: </span>${ICONS.warn} ${validation.facetSummary.missing.length} record properties lack facet definitions: ${validation.facetSummary.missing.join(', ')}</div>`;
                         } else if (validation.facetSummary.total > 0) {
-                            html += `<div class="status-success-line"><span class="sr-only">Success: </span><span aria-hidden="true" class="status-icon">✓</span> All record properties have facet definitions</div>`;
+                            html += `<div class="status-success-line"><span class="sr-only">Success: </span>${ICONS.check} All record properties have facet definitions</div>`;
                         }
                     }
                 // Behavior validation
                 if (validation.behaviorSummary) {
                     if (validation.behaviorSummary.missing && validation.behaviorSummary.missing.length) {
-                        html += `<div class="status-warning-line"><span class="sr-only">Warning: </span><span aria-hidden="true" class="status-icon">⚠</span> ${validation.behaviorSummary.missing.length} selector(s) lack behavior definitions: ${validation.behaviorSummary.missing.join(', ')}</div>`;
+                        html += `<div class="status-warning-line"><span class="sr-only">Warning: </span>${ICONS.warn} ${validation.behaviorSummary.missing.length} selector(s) lack behavior definitions: ${validation.behaviorSummary.missing.join(', ')}</div>`;
                     } else if (validation.behaviorSummary.total > 0) {
-                        html += `<div class="status-success-line"><span class="sr-only">Success: </span><span aria-hidden="true" class="status-icon">✓</span> All selectors have behavior definitions</div>`;
+                        html += `<div class="status-success-line"><span class="sr-only">Success: </span>${ICONS.check} All selectors have behavior definitions</div>`;
                     }
                 }
                 // Selector/DOM validation
                 if (validation.selectorSummary) {
-                    html += `<div class="status-success-line"><span class="sr-only">Success: </span><span aria-hidden="true" class="status-icon">✓</span> ${validation.selectorSummary.domValid} DOM selector(s) valid</div>`;
-                    html += `<div class="status-success-line"><span class="sr-only">Success: </span><span aria-hidden="true" class="status-icon">✓</span> ${validation.selectorSummary.jsonValid} JSON path(s) valid</div>`;
+                    html += `<div class="status-success-line"><span class="sr-only">Success: </span>${ICONS.check} ${validation.selectorSummary.domValid} DOM selector(s) valid</div>`;
+                    html += `<div class="status-success-line"><span class="sr-only">Success: </span>${ICONS.check} ${validation.selectorSummary.jsonValid} JSON path(s) valid</div>`;
                 }
                 // Behavior mapping
                 if (validation.behaviorSummary && typeof validation.behaviorSummary.mapped === 'number') {
-                    html += `<div class="status-success-line"><span class="sr-only">Success: </span><span aria-hidden="true" class="status-icon">✓</span> ${validation.behaviorSummary.mapped} behavior(s) properly mapped</div>`;
+                    html += `<div class="status-success-line"><span class="sr-only">Success: </span>${ICONS.check} ${validation.behaviorSummary.mapped} behavior(s) properly mapped</div>`;
                 }
                 // Errors, warnings, passes
                 validation.errors?.forEach(err => {
-                    html += `<div class="status-error-line"><span class="sr-only">Error: </span><span aria-hidden="true" class="status-icon">✗</span> ${err}</div>`;
+                    html += `<div class="status-error-line"><span class="sr-only">Error: </span>${ICONS.cross} ${err}</div>`;
                 });
                 validation.warnings?.forEach(w => {
-                    html += `<div class="status-warning-line"><span class="sr-only">Warning: </span><span aria-hidden="true" class="status-icon">⚠</span> ${w}</div>`;
+                    html += `<div class="status-warning-line"><span class="sr-only">Warning: </span>${ICONS.warn} ${w}</div>`;
                 });
                 validation.passed?.forEach(p => {
-                    html += `<div class="status-success-line"><span class="sr-only">Success: </span><span aria-hidden="true" class="status-icon">✓</span> ${p}</div>`;
+                    html += `<div class="status-success-line"><span class="sr-only">Success: </span>${ICONS.check} ${p}</div>`;
                 });
                 // Orphaned selectors (accessible heading and list)
                 if (validation.orphanedSelectors?.length) {
@@ -2208,23 +2428,134 @@
         document.addEventListener('DOMContentLoaded', () => {
             window.jimViewer = new JIMViewer();
 
+            // Helper to update visible current file label
+            function setCurrentFileLabel(text) {
+                try {
+                    const el = document.getElementById('current-file');
+                    if (!el) return;
+                    const full = String(text || 'No file loaded');
+                    // Extract basename for display (strip path and query)
+                    let path = full;
+                    try {
+                        // If it's an absolute URL, use URL to get pathname
+                        const u = new URL(full, window.location.href);
+                        path = u.pathname || full;
+                    } catch (e) {
+                        // not a full URL, keep as-is
+                        path = full.split('?')[0];
+                    }
+                    path = path.replace(/\\/g, '/');
+                    const parts = path.split('/').filter(Boolean);
+                    let name = parts.length ? parts[parts.length - 1] : path;
+                    if (!name) name = full;
+                    // Display the full basename (CSS will visually ellipsize if needed)
+                    el.textContent = name;
+                    // Preserve full value in title for tooltip
+                    el.setAttribute('title', full);
+                } catch (e) { /* ignore */ }
+            }
+
+            // Helper: try fetching a path using several sensible URL variants (relative, absolute, origin-prefixed)
+            async function tryFetchExampleWithVariants(path) {
+                const variants = [];
+                if (!path) return null;
+                // Keep the original value first
+                variants.push(path);
+                // Ensure leading slash variant
+                if (!path.startsWith('/')) variants.push('/' + path);
+                // Origin-prefixed absolute URL
+                try { variants.push(window.location.origin + (path.startsWith('/') ? path : '/' + path)); } catch (e) {}
+                // Relative to current document
+                variants.push('./' + path.replace(/^\/+/, ''));
+                // Deduplicate while preserving order
+                const seen = new Set();
+                const uniq = variants.filter(v => { if (!v) return false; if (seen.has(v)) return false; seen.add(v); return true; });
+
+                for (const candidate of uniq) {
+                    try {
+                        console.debug('[JIMViewer] attempting fetch for example candidate:', candidate);
+                        const res = await fetch(candidate);
+                        if (res && res.ok) {
+                            const text = await res.text();
+                            const ext = candidate.split('.').pop().toLowerCase();
+                            return { text, ext, url: candidate };
+                        } else {
+                            console.debug('[JIMViewer] fetch returned non-ok for', candidate, res && res.status);
+                        }
+                    } catch (e) {
+                        console.debug('[JIMViewer] fetch failed for', candidate, e && e.message ? e.message : e);
+                    }
+                }
+                return null;
+            }
+
+            // Helper: populate the native file input from fetched text so the standard file dialog state
+            // reflects the autoloaded example. This creates a Blob/File and assigns it to the input via
+            // a DataTransfer object, then dispatches a change event so existing handlers run.
+            async function populateNativeFileInputFromFetch(displayPath, text, ext) {
+                try {
+                    const input = document.getElementById('jim-file');
+                    if (!input) return;
+
+                    // Determine MIME type by extension
+                    const mime = (ext === 'svg') ? 'image/svg+xml' : (ext === 'html' || ext === 'htm') ? 'text/html' : 'text/plain';
+
+                    // Create a blob from the text and a File with a sensible filename
+                    const filename = (function () {
+                        try {
+                            const u = new URL(displayPath, window.location.href);
+                            return (u.pathname || '').split('/').pop() || ('example.' + ext);
+                        } catch (e) {
+                            const parts = String(displayPath || '').split('/').filter(Boolean);
+                            return parts.length ? parts[parts.length - 1] : ('example.' + ext);
+                        }
+                    })();
+
+                    const blob = new Blob([text], { type: mime });
+                    let file;
+                    try {
+                        file = new File([blob], filename, { type: mime });
+                    } catch (e) {
+                        // Some older browsers may not support File constructor; fall back to Blob with name prop
+                        file = blob;
+                        file.name = filename;
+                    }
+
+                    // Use DataTransfer to set input.files
+                    const dt = new DataTransfer();
+                    dt.items.add(file);
+                    input.files = dt.files;
+
+                    // Update visible label
+                    setCurrentFileLabel(filename || displayPath || 'Autoloaded file');
+
+                    // Dispatch change so existing listeners react (FileReader path)
+                    const ev = new Event('change', { bubbles: true });
+                    input.dispatchEvent(ev);
+                } catch (e) {
+                    console.warn('[JIMViewer] populateNativeFileInputFromFetch failed:', e);
+                    throw e;
+                }
+            }
+
             // Auto-load example via query parameter, e.g. ?example=examples/testimage_0.svg
             (async function tryAutoLoadFromQuery() {
                 try {
                     const params = new URLSearchParams(window.location.search);
                     const examplePath = params.get('example');
                     if (examplePath) {
-                        try {
-                            const res = await fetch(examplePath);
-                            if (res && res.ok) {
-                                const text = await res.text();
-                                const ext = examplePath.split('.').pop().toLowerCase();
-                                window.jimViewer.handleFileLoad(text, ext);
+                        const fetched = await tryFetchExampleWithVariants(examplePath);
+                        if (fetched) {
+                            // Try to populate the native file input so the standard file dialog state reflects the autoloaded file.
+                            if (typeof populateNativeFileInputFromFetch === 'function') {
+                                await populateNativeFileInputFromFetch(fetched.url || examplePath, fetched.text, fetched.ext);
                             } else {
-                                console.warn('[JIMViewer] Failed to fetch example from query param:', examplePath, res && res.status);
+                                // Fallback: directly handle the load and update label
+                                window.jimViewer.handleFileLoad(fetched.text, fetched.ext);
+                                setCurrentFileLabel(fetched.url || examplePath);
                             }
-                        } catch (e) {
-                            console.warn('[JIMViewer] Error fetching example from query param:', e);
+                        } else {
+                            console.warn('[JIMViewer] Failed to fetch example from query param (all candidates failed):', examplePath);
                         }
                     }
                 } catch (e) {
@@ -2233,32 +2564,226 @@
             })();
 
             // Listen for postMessage from an embedding harness (tests/auto-load.html)
-            // Expected message shape: { type: 'autoLoadExample', path: '/examples/testimage_0.svg' }
+            // Supports messages:
+            //  - { type: 'autoLoadExample', path: '/examples/testimage_0.svg' }
+            //  - { type: 'inspect', selector: 'svg #elemId' }
             window.addEventListener('message', async (ev) => {
                 try {
                     // Only accept same-origin messages for safety in CI/local runs
                     if (!ev || ev.origin !== window.location.origin) return;
                     const data = ev.data || {};
-                    if (data.type !== 'autoLoadExample' || !data.path) return;
-                    try {
-                        const res = await fetch(data.path);
-                        if (!res || !res.ok) {
-                            console.warn('[JIMViewer] Failed to fetch auto-load path:', data.path, res && res.status);
-                            return;
+
+                    // Auto-load example into the viewer (harness can postMessage { type: 'autoLoadExample', path })
+                    if (data.type === 'autoLoadExample' && data.path) {
+                        try {
+                            const fetched = await tryFetchExampleWithVariants(data.path);
+                            if (!fetched) {
+                                console.warn('[JIMViewer] Failed to fetch auto-load path (all candidates failed):', data.path);
+                                return;
+                            }
+                            if (window.jimViewer) {
+                                if (typeof populateNativeFileInputFromFetch === 'function') {
+                                    try {
+                                        await populateNativeFileInputFromFetch(fetched.url || data.path, fetched.text, fetched.ext);
+                                    } catch (e) {
+                                        // fallback to direct load
+                                        if (typeof window.jimViewer.handleFileLoad === 'function') window.jimViewer.handleFileLoad(fetched.text, fetched.ext);
+                                        setCurrentFileLabel(fetched.url || data.path);
+                                    }
+                                } else if (typeof window.jimViewer.handleFileLoad === 'function') {
+                                    window.jimViewer.handleFileLoad(fetched.text, fetched.ext);
+                                    setCurrentFileLabel(fetched.url || data.path);
+                                }
+                            }
+                        } catch (e) {
+                            console.warn('[JIMViewer] Error fetching auto-load path:', e);
                         }
-                        const text = await res.text();
-                        const ext = data.path.split('.').pop().toLowerCase();
-                        if (window.jimViewer && typeof window.jimViewer.handleFileLoad === 'function') {
-                            window.jimViewer.handleFileLoad(text, ext);
+                        return;
+                    }
+
+                    // Inspect a CSS selector or JIM selector key inside the viewer's current visualization
+                    if (data.type === 'inspect' && data.selector) {
+                        try {
+                            const viewer = window.jimViewer;
+                            const originalSelector = String(data.selector);
+                            const selectors = viewer?.jimData?.selectors || {};
+                            let selectorKey = null;
+                            let usedSelector = originalSelector;
+
+                            // If the caller passed a JIM selector key (e.g. 'chartTitle'), map it to its dom value
+                            if (selectors && Object.prototype.hasOwnProperty.call(selectors, originalSelector)) {
+                                selectorKey = originalSelector;
+                                usedSelector = selectors[originalSelector].dom || originalSelector;
+                            }
+
+                            // Try to find the element inside the live visualization using the chosen selector
+                            let el = null;
+                            try {
+                                const viz = document.getElementById('visualization');
+                                if (viz) el = viz.querySelector(usedSelector);
+                            } catch (e) { el = null; }
+
+                            // If nothing matched and the caller sent a plain token like 'chartTitle', try treating it as an id
+                            if (!el && /^[A-Za-z0-9_\-]+$/.test(originalSelector)) {
+                                try {
+                                    const viz = document.getElementById('visualization');
+                                    if (viz) {
+                                        const idSel = '#' + originalSelector;
+                                        el = viz.querySelector(idSel);
+                                        if (el) usedSelector = idSel;
+                                    }
+                                } catch (e) { /* ignore */ }
+                            }
+
+                            if (el) {
+                                // If we still don't have a selectorKey, try to find one by matching existing JIM selectors
+                                if (!selectorKey && selectors) {
+                                    for (const [key, sel] of Object.entries(selectors || {})) {
+                                        try { if (el.matches(sel.dom)) { selectorKey = key; break; } } catch {}
+                                    }
+                                }
+
+                                // Show the appropriate info panel using the viewer instance
+                                if (viewer && typeof viewer.showElementInfo === 'function' && selectorKey) viewer.showElementInfo(selectorKey, 'external', el);
+                                else if (viewer && typeof viewer.showNonJIMElementInfo === 'function' && !selectorKey) viewer.showNonJIMElementInfo(el, 'external');
+                                else {
+                                    // Fallback: log that viewer methods are unavailable
+                                    console.warn('[JIMViewer] inspect: viewer instance not available to show info panel.');
+                                }
+
+                                // Send a response back to the sender so harness/CI can observe success
+                                try {
+                                    if (ev.source && ev.origin) {
+                                        ev.source.postMessage({ type: 'inspect-result', matched: true, mapped: !!selectorKey, selector: originalSelector, usedSelector, selectorKey: selectorKey || null }, ev.origin);
+                                    }
+                                } catch (e) { /* ignore postMessage failures */ }
+                            } else {
+                                console.warn('[JIMViewer] inspect: selector did not match any element in visualization:', originalSelector);
+                                try {
+                                    if (ev.source && ev.origin) {
+                                        ev.source.postMessage({ type: 'inspect-result', matched: false, selector: originalSelector }, ev.origin);
+                                    }
+                                } catch (e) { /* ignore postMessage failures */ }
+                            }
+                        } catch (e) {
+                            console.warn('[JIMViewer] Error handling inspect message:', e);
                         }
-                    } catch (e) {
-                        console.warn('[JIMViewer] Error fetching auto-load path:', e);
+                        return;
                     }
                 } catch (e) {
                     // swallow any message handler errors
                 }
             });
         });
+
+        // Accessibility helper: replace small glyph dots used to show computed colors
+        // with deterministic color swatches that have explicit background so axe can compute contrast.
+        (function() {
+            function parseRgb(str) {
+                if (!str) return null;
+                str = String(str).trim();
+                let m;
+                if (str.startsWith('rgb')) {
+                    m = str.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/i);
+                    if (m) return [parseInt(m[1],10), parseInt(m[2],10), parseInt(m[3],10)];
+                }
+                if (str[0] === '#') {
+                    const hex = str.slice(1);
+                    if (hex.length === 3) return [parseInt(hex[0]+hex[0],16), parseInt(hex[1]+hex[1],16), parseInt(hex[2]+hex[2],16)];
+                    if (hex.length === 6) return [parseInt(hex.slice(0,2),16), parseInt(hex.slice(2,4),16), parseInt(hex.slice(4,6),16)];
+                }
+                return null;
+            }
+
+            function relLum([r,g,b]){
+                const srgb = [r,g,b].map(v => v/255).map(c => c <= 0.03928 ? c/12.92 : Math.pow((c+0.055)/1.055, 2.4));
+                return 0.2126*srgb[0] + 0.7152*srgb[1] + 0.0722*srgb[2];
+            }
+
+            function contrast(a,b){ const L1 = relLum(a); const L2 = relLum(b); const light = Math.max(L1,L2); const dark = Math.min(L1,L2); return (light + 0.05) / (dark + 0.05); }
+
+            function enhanceComputedDots(root=document) {
+                try {
+                    const dots = Array.from(root.querySelectorAll('.computed-dot'));
+                    dots.forEach(dot => {
+                        try {
+                            const cs = window.getComputedStyle(dot);
+                            let colorStr = cs.color || cs.fill || cs.backgroundColor || dot.getAttribute('data-color');
+                            let rgb = parseRgb(colorStr);
+                            // If color isn't parseable (e.g. 'none'), try to read adjacent text node that contains the textual color value
+                            if (!rgb) {
+                                const next = dot.nextSibling;
+                                if (next && next.nodeType === Node.TEXT_NODE) {
+                                    // e.g. ' rgb(96, 114, 169)'
+                                    const txt = next.textContent && next.textContent.trim();
+                                    // attempt to extract rgb(...) or #hex
+                                    const m = txt && txt.match(/(rgba?\([^)]+\)|#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6}))/);
+                                    if (m) rgb = parseRgb(m[1]);
+                                }
+                            }
+                            if (!rgb) return;
+
+                            // Build swatch element (match inline swatch sizing: 10px inner, 16px outer)
+                            const swatch = document.createElement('span');
+                            swatch.className = 'computed-dot-swatch';
+                            swatch.setAttribute('aria-hidden', 'true');
+                            swatch.style.display = 'block';
+                            swatch.style.width = '10px';
+                            swatch.style.height = '10px';
+                            swatch.style.borderRadius = '50%';
+                            swatch.style.backgroundColor = `rgb(${rgb.join(',')})`;
+
+                            // Determine effective background at insertion point by walking up to the nearest
+                            // ancestor with a non-transparent computed background. If none found, fall back to white.
+                            function findEffectiveBackgroundColor(node) {
+                                let cur = node && node.parentElement;
+                                while (cur) {
+                                    try {
+                                        const bg = window.getComputedStyle(cur).backgroundColor;
+                                        if (bg && bg !== 'transparent' && !bg.startsWith('rgba(0, 0, 0, 0)')) return bg;
+                                    } catch (e) { /* ignore */ }
+                                    cur = cur.parentElement;
+                                }
+                                return '#ffffff';
+                            }
+                            const effectiveBgStr = findEffectiveBackgroundColor(dot);
+                            const effectiveBgRgb = parseRgb(effectiveBgStr) || [255,255,255];
+                            const effContrast = contrast(rgb, effectiveBgRgb);
+                            // Choose neutral background: prefer effective background if it gives >= 3:1 contrast,
+                            // otherwise fall back to white/black that gives the best contrast.
+                            const whiteContrast = contrast(rgb, [255,255,255]);
+                            const blackContrast = contrast(rgb, [0,0,0]);
+                            const wrap = document.createElement('span');
+                            wrap.className = 'computed-dot-wrap';
+                            if (effContrast >= 3) {
+                                wrap.style.background = `rgb(${effectiveBgRgb.join(',')})`;
+                            } else {
+                                wrap.style.background = (whiteContrast >= blackContrast) ? '#ffffff' : '#000000';
+                            }
+                            // Match inline wrap sizing and spacing
+                            wrap.style.width = '16px';
+                            wrap.style.height = '16px';
+                            wrap.style.borderRadius = '8px';
+                            wrap.style.boxShadow = 'inset 0 0 0 1px rgba(0,0,0,0.06)';
+                            wrap.style.display = 'inline-flex';
+                            wrap.style.alignItems = 'center';
+                            wrap.style.justifyContent = 'center';
+                            wrap.style.marginRight = '8px';
+                            wrap.style.verticalAlign = 'middle';
+                            wrap.style.overflow = 'visible';
+
+                            // Replace original dot with wrap containing swatch
+                            dot.parentNode && dot.parentNode.replaceChild(wrap, dot);
+                            wrap.appendChild(swatch);
+                        } catch (e) { /* per-dot failures ignored */ }
+                    });
+                } catch (e) { /* ignore overall failures */ }
+            }
+
+            // Run after DOM ready and also expose on window for dynamic updates
+            try { enhanceComputedDots(document); } catch (e) {}
+            window.enhanceComputedDots = enhanceComputedDots;
+        })();
 
         // Global function to handle inventory item clicks
         window.handleInventoryItemClick = function (category, idx) {

--- a/jim-viewer.html
+++ b/jim-viewer.html
@@ -352,33 +352,32 @@
 </head>
 <body>
     <a href="#main-content" class="skip-link">Skip to main content</a>
-    
     <div class="container">
         <!-- Screen reader help for SVG navigation -->
         <div id="svg-sr-help" class="sr-only" aria-live="polite">
             Visualization area. Press 'i' to jump to the first available list (Spec Compliance and then Orphaned Selectors if present, otherwise SVG Element Inventory). In the SVG Element Inventory, use Tab to move between items and Enter to open details. The Spec Compliance and Orphaned Selectors lists are not interactive.
         </div>
-        <header role="banner">
+        <header>
             <h1>JIM Metadata Viewer</h1>
             <p class="subtitle">Load and explore JSON for Interactive Media (JIM) documents</p>
         </header>
 
-        <main id="main-content" role="main">
+        <main id="main-content">
             <section class="input-section" aria-labelledby="upload-heading">
                 <h2 id="upload-heading" class="sr-only">File Upload</h2>
                 <div class="file-input-wrapper">
                     <label for="jim-file">Upload SVG or HTML file:</label>
-                    <input type="file" id="jim-file" accept=".svg,.html,.htm" aria-describedby="file-help" />
+                    <input type="file" id="jim-file" accept=".svg,.html,.htm" aria-describedby="file-help">
                     <div id="file-help" class="file-help">Supported: SVG files (with or without JIM metadata) and HTML files containing SVG elements.</div>
                 </div>
                 <div id="metadata-summary" aria-live="polite"></div>
                 <div id="status-messages" aria-live="polite" aria-atomic="true"></div>
             </section>
 
-            <div id="selector-list-panel" class="selector-panel hidden"></div>
+            <section id="selector-list-panel" class="selector-panel hidden"></section>
             <section class="viewer-section" aria-labelledby="visualization-heading">
                 <h2 id="visualization-heading">Interactive Visualization</h2>
-                <div id="visualization" aria-live="polite" aria-label="SVG visualization display area">
+                <div id="visualization" aria-live="polite" aria-labelledby="visualization-heading">
                     <div class="empty-state">
                         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
                             <path d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
@@ -397,7 +396,7 @@
         <aside id="info-panel" class="info-panel" role="region" aria-labelledby="element-info-heading" tabindex="-1">
             <div class="info-panel-header">
                 <h3 id="element-info-heading">Element Information</h3>
-                <button class="close-btn" aria-label="Close information panel">&times;</button>
+                <button type="button" class="close-btn" aria-label="Close information panel">&times;</button>
             </div>
             <div id="info-content" class="info-content"></div>
         </aside>

--- a/jim-viewer.html
+++ b/jim-viewer.html
@@ -389,7 +389,7 @@
 
                         <section class="viewer-section hidden" id="analysis-section" aria-labelledby="analysis-heading">
               <h2 id="analysis-heading">Detailed Analysis</h2>
-              <div id="analysis-content"></div>
+                            <section id="analysis-content"></section>
             </section>
         </main>
 

--- a/jim-viewer.html
+++ b/jim-viewer.html
@@ -286,6 +286,10 @@
             opacity: 0.5;
         }
 
+        .empty-state p {
+            color: #475569; /* darker muted color for WCAG contrast */
+        }
+
         .sr-only {
             position: absolute;
             width: 1px;

--- a/jim-viewer.html
+++ b/jim-viewer.html
@@ -2207,6 +2207,57 @@
         // Ensure the JIMViewer is initialized when the DOM is ready
         document.addEventListener('DOMContentLoaded', () => {
             window.jimViewer = new JIMViewer();
+
+            // Auto-load example via query parameter, e.g. ?example=examples/testimage_0.svg
+            (async function tryAutoLoadFromQuery() {
+                try {
+                    const params = new URLSearchParams(window.location.search);
+                    const examplePath = params.get('example');
+                    if (examplePath) {
+                        try {
+                            const res = await fetch(examplePath);
+                            if (res && res.ok) {
+                                const text = await res.text();
+                                const ext = examplePath.split('.').pop().toLowerCase();
+                                window.jimViewer.handleFileLoad(text, ext);
+                            } else {
+                                console.warn('[JIMViewer] Failed to fetch example from query param:', examplePath, res && res.status);
+                            }
+                        } catch (e) {
+                            console.warn('[JIMViewer] Error fetching example from query param:', e);
+                        }
+                    }
+                } catch (e) {
+                    // ignore URL parsing errors in odd environments
+                }
+            })();
+
+            // Listen for postMessage from an embedding harness (tests/auto-load.html)
+            // Expected message shape: { type: 'autoLoadExample', path: '/examples/testimage_0.svg' }
+            window.addEventListener('message', async (ev) => {
+                try {
+                    // Only accept same-origin messages for safety in CI/local runs
+                    if (!ev || ev.origin !== window.location.origin) return;
+                    const data = ev.data || {};
+                    if (data.type !== 'autoLoadExample' || !data.path) return;
+                    try {
+                        const res = await fetch(data.path);
+                        if (!res || !res.ok) {
+                            console.warn('[JIMViewer] Failed to fetch auto-load path:', data.path, res && res.status);
+                            return;
+                        }
+                        const text = await res.text();
+                        const ext = data.path.split('.').pop().toLowerCase();
+                        if (window.jimViewer && typeof window.jimViewer.handleFileLoad === 'function') {
+                            window.jimViewer.handleFileLoad(text, ext);
+                        }
+                    } catch (e) {
+                        console.warn('[JIMViewer] Error fetching auto-load path:', e);
+                    }
+                } catch (e) {
+                    // swallow any message handler errors
+                }
+            });
         });
 
         // Global function to handle inventory item clicks

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "jim_previewer",
+  "version": "1.0.0",
+  "description": "> **License:** MIT — See [LICENSE](LICENSE) for details.",
+  "main": "index.js",
+  "directories": {
+    "example": "examples"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "lint:html": "html-validate \"jim-viewer.html\" \"**/*.html\""
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Inclusio-Community/JIM_previewer.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/Inclusio-Community/JIM_previewer/issues"
+  },
+  "homepage": "https://github.com/Inclusio-Community/JIM_previewer#readme",
+  "devDependencies": {
+    "html-validate": "^10.1.0"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "lint:html": "html-validate \"jim-viewer.html\" \"**/*.html\""
+  "lint:html": "html-validate \"jim-viewer.html\" \"tests/*.html\"",
+    "axe-report": "node scripts/axe-report.js",
+    "ci:axe": "node scripts/ci-run-axe.js --base-url=http://127.0.0.1:8080 --out-dir=axe-output --fail-on-violations=false"
   },
   "repository": {
     "type": "git",
@@ -22,6 +24,8 @@
   },
   "homepage": "https://github.com/Inclusio-Community/JIM_previewer#readme",
   "devDependencies": {
-    "html-validate": "^10.1.0"
+    "html-validate": "^10.1.0",
+    "playwright": "^1.55.1",
+    "yargs": "^18.0.0"
   }
 }

--- a/scripts/axe-report.js
+++ b/scripts/axe-report.js
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+function usage() {
+  console.log('Usage: node scripts/axe-report.js <axe-json-file> [--fail-on-violations] [--top N]');
+  process.exit(1);
+}
+
+const argv = process.argv.slice(2);
+if (!argv[0]) usage();
+const inputPath = argv[0];
+const failOnViolations = argv.includes('--fail-on-violations');
+const topArgIndex = argv.findIndex(a => a === '--top');
+let topN = 5;
+if (topArgIndex !== -1 && argv[topArgIndex+1]) topN = parseInt(argv[topArgIndex+1], 10) || 5;
+
+if (!fs.existsSync(inputPath)) {
+  console.error('File not found:', inputPath);
+  process.exit(2);
+}
+
+const raw = fs.readFileSync(inputPath, 'utf8');
+let json;
+try {
+  json = JSON.parse(raw);
+} catch (e) {
+  console.error('Failed to parse JSON:', e.message);
+  process.exit(3);
+}
+
+function short(node) {
+  // node.target is an array; join targets
+  const target = (node.target || []).slice(0,3).join(', ');
+  let html = node.html || '';
+  if (html.length > 240) html = html.slice(0,240) + '…';
+  return { target, html };
+}
+
+const summary = {
+  url: json.url || null,
+  timestamp: json.timestamp || new Date().toISOString(),
+  engine: (json.testEngine && json.testEngine.version) || 'unknown',
+  counts: {
+    violations: (json.violations || []).length,
+    incomplete: (json.incomplete || []).length,
+    passes: (json.passes || []).length,
+    inapplicable: (json.inapplicable || []).length
+  },
+  violations: [],
+  incomplete: []
+};
+
+function gather(list, into, limit) {
+  (list || []).forEach(rule => {
+    const item = {
+      id: rule.id,
+      impact: rule.impact,
+      help: rule.help,
+      helpUrl: rule.helpUrl,
+      description: rule.description,
+      nodes: (rule.nodes || []).slice(0, limit).map(n => ({ target: n.target, html: (n.html||'').replace(/\s+/g,' ').trim() }))
+    };
+    into.push(item);
+  });
+}
+
+gather(json.violations, summary.violations, topN);
+gather(json.incomplete, summary.incomplete, topN);
+
+const outBase = path.join(path.dirname(inputPath), path.basename(inputPath, path.extname(inputPath)));
+const outJson = outBase + '-summary.json';
+const outHtml = outBase + '-summary.html';
+fs.writeFileSync(outJson, JSON.stringify(summary, null, 2), 'utf8');
+
+function esc(s) { return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
+
+let html = `<!doctype html><html><head><meta charset="utf-8"><title>Axe summary for ${esc(summary.url||'report')}</title>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<style>body{font-family:system-ui,Arial,Helvetica;margin:18px;color:#111}h1,h2{margin:0 0 8px}pre{white-space:pre-wrap;background:#fafafa;padding:8px;border-radius:6px;border:1px solid #eee}table{border-collapse:collapse;width:100%;margin-top:8px}td,th{border:1px solid #eee;padding:6px;text-align:left} .badge{display:inline-block;padding:2px 6px;border-radius:4px;background:#f1f5f9;margin-right:6px;font-size:12px}</style>
+</head><body>
+<h1>Axe Report Summary</h1>
+<div><strong>URL:</strong> ${esc(summary.url||'N/A')}</div>
+<div><strong>Timestamp:</strong> ${esc(summary.timestamp)}</div>
+<div style="margin-top:8px">
+  <span class="badge">Violations: ${summary.counts.violations}</span>
+  <span class="badge">Incomplete: ${summary.counts.incomplete}</span>
+  <span class="badge">Passes: ${summary.counts.passes}</span>
+  <span class="badge">Inapplicable: ${summary.counts.inapplicable}</span>
+</div>
+`;
+
+function renderGroup(title, items) {
+  if (!items || !items.length) return `<h2>${esc(title)}: none</h2>`;
+  let out = `<h2>${esc(title)}</h2>`;
+  items.forEach(rule => {
+    out += `<h3>${esc(rule.id)} <small>(${esc(rule.impact||'')})</small></h3>`;
+    out += `<div>${esc(rule.help)} - <a href="${esc(rule.helpUrl)}" target="_blank">details</a></div>`;
+    out += `<table><thead><tr><th>Target</th><th>HTML snippet</th></tr></thead><tbody>`;
+    rule.nodes.forEach(n => {
+      out += `<tr><td><pre>${esc(Array.isArray(n.target)?n.target.join('\n'):String(n.target))}</pre></td><td><pre>${esc(n.html||'')}</pre></td></tr>`;
+    });
+    out += `</tbody></table>`;
+  });
+  return out;
+}
+
+html += renderGroup('Violations (top rules)', summary.violations);
+html += renderGroup('Incomplete (top rules)', summary.incomplete);
+html += `<hr><div>Full JSON summary: <a href="${path.basename(outJson)}">${path.basename(outJson)}</a></div>`;
+html += `</body></html>`;
+
+fs.writeFileSync(outHtml, html, 'utf8');
+
+console.log('Summary written:', outJson, outHtml);
+if (failOnViolations && summary.counts.violations > 0) {
+  console.error('Failing on violations:', summary.counts.violations);
+  process.exit(5);
+}
+process.exit(0);

--- a/scripts/ci-run-axe.js
+++ b/scripts/ci-run-axe.js
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const { chromium } = require('playwright');
+
+// Examples to test (same defaults used by the harness)
+const defaultExamples = [
+  '/examples/testimage_0.svg',
+  '/examples/simple_svg_triangle.svg',
+  '/examples/triangle-complete-with-jim-metadata.svg',
+  '/examples/triangle-with-orphan-selectors.svg',
+  '/examples/Division_of_energy_in_the_Universe.svg'
+];
+
+// Lightweight argument parsing (avoids external yargs dependency/runtime API mismatch)
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const out = {
+    'base-url': 'http://127.0.0.1:8080',
+    'examples': [],
+    'include-svg': false,
+    'out-dir': 'axe-output',
+    'fail-on-violations': false
+  };
+  args.forEach(a => {
+    if (a.startsWith('--base-url=')) out['base-url'] = a.split('=')[1];
+    else if (a.startsWith('--out-dir=')) out['out-dir'] = a.split('=')[1];
+    else if (a === '--include-svg') out['include-svg'] = true;
+    else if (a === '--no-include-svg') out['include-svg'] = false;
+    else if (a === '--fail-on-violations') out['fail-on-violations'] = true;
+    else if (a.startsWith('--examples=')) out['examples'] = a.split('=')[1].split(',').map(s => s.trim()).filter(Boolean);
+  });
+  return out;
+}
+
+const argv = parseArgs();
+const examples = (argv.examples && argv.examples.length) ? argv.examples : defaultExamples;
+
+(async function run() {
+  if (!fs.existsSync(argv['out-dir'])) fs.mkdirSync(argv['out-dir'], { recursive: true });
+
+  const browser = await chromium.launch({ args: ['--no-sandbox'] });
+  const page = await browser.newPage();
+
+  let overallViolations = 0;
+  for (const ex of examples) {
+    try {
+      const examplePath = ex.startsWith('/') ? ex.slice(1) : ex;
+      const url = `${argv['base-url'].replace(/\/$/, '')}/jim-viewer.html?example=${encodeURIComponent(examplePath)}`;
+      console.log(`Visiting: ${url}`);
+      const resp = await page.goto(url, { waitUntil: 'load', timeout: 30000 });
+      if (!resp || !resp.ok()) {
+        console.warn(`Warning: load returned status ${resp && resp.status()}`);
+      }
+
+      // Give the viewer a moment to render the SVG and any dynamic UI
+      await page.waitForTimeout(500);
+
+      // Optionally hide visualization container to exclude SVG geometry
+      if (!argv['include-svg']) {
+        await page.evaluate(() => {
+          try {
+            const viz = document.getElementById('visualization');
+            if (viz) {
+              viz.__ci_prev_display = viz.getAttribute('style');
+              viz.style.setProperty('display', 'none', 'important');
+              viz.setAttribute('aria-hidden', 'true');
+            }
+          } catch (e) { /* ignore */ }
+        });
+        // small delay after hiding
+        await page.waitForTimeout(200);
+      }
+
+      // Inject axe if not present
+      await page.addScriptTag({ url: 'https://cdnjs.cloudflare.com/ajax/libs/axe-core/4.8.4/axe.min.js' });
+
+      // Run axe in the page context and collect results
+      const result = await page.evaluate(async () => {
+        // wait a short moment for any UI updates
+        await new Promise(r => setTimeout(r, 200));
+        // axe is expected to be available globally
+        if (!window.axe) throw new Error('axe not found in page');
+        const res = await window.axe.run(document);
+        return res;
+      });
+
+      const base = path.basename(examplePath).replace(/[^a-zA-Z0-9_.-]/g, '_');
+      const outPath = path.join(argv['out-dir'], `axe-${base}.json`);
+      fs.writeFileSync(outPath, JSON.stringify(result, null, 2), 'utf8');
+      console.log(`Wrote ${outPath} — violations: ${(result.violations||[]).length}, incomplete: ${(result.incomplete||[]).length}`);
+
+      overallViolations += (result.violations || []).length;
+
+      // restore hidden viz (best-effort)
+      if (!argv['include-svg']) {
+        await page.evaluate(() => {
+          try {
+            const viz = document.getElementById('visualization');
+            if (viz) {
+              if (viz.__ci_prev_display !== null) viz.setAttribute('style', viz.__ci_prev_display);
+              else viz.removeAttribute('style');
+              if (viz.getAttribute('aria-hidden') === 'true') viz.removeAttribute('aria-hidden');
+            }
+          } catch (e) { /* ignore */ }
+        });
+      }
+
+    } catch (err) {
+      console.error('Error while processing', ex, err && err.message ? err.message : err);
+    }
+  }
+
+  await browser.close();
+
+  console.log(`Total violations across examples: ${overallViolations}`);
+  if (argv['fail-on-violations'] && overallViolations > 0) {
+    console.error('Failing due to violations');
+    process.exit(2);
+  }
+  process.exit(0);
+})();

--- a/tests/auto-load.html
+++ b/tests/auto-load.html
@@ -1,8 +1,8 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>JIM Previewer - Auto Load Test</title>
   <style>
     body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial; }

--- a/tests/auto-load.html
+++ b/tests/auto-load.html
@@ -27,7 +27,17 @@
     const defaultExamples = [
       '/examples/testimage_0.svg',
       '/examples/testimage_1.svg',
-      '/examples/testimage_2.svg'
+      '/examples/testimage_2.svg',
+      '/examples/testimage_3.svg',
+      '/examples/testimage_4.svg',
+      '/examples/simple_svg_triangle.svg',
+      '/examples/triangle-complete-with-jim-metadata.svg',
+      '/examples/triangle-with-orphan-selectors.svg',
+      '/examples/Division_of_energy_in_the_Universe.svg',
+      '/examples/Distribution_of_the_workforce_across_economic_sectors_in_India_2019.svg',
+      '/examples/College_enrollment_in_public_and_private_institutions_in_the_U_S__1965_to_2028.svg',
+      '/examples/Number_of_Xbox_Live_MAU_Q1_2016___Q4_2019.svg',
+      '/examples/Unemployment_rate_in_Greece_1999_2019.svg'
     ];
 
     function parseExamplesFromQuery() {

--- a/tests/auto-load.html
+++ b/tests/auto-load.html
@@ -22,22 +22,14 @@
     <button id="next" type="button">Next ▶</button>
   </div>
   <iframe id="viewer" src="/jim-viewer.html?example=examples/testimage_0.svg" title="JIM Viewer test harness"></iframe>
-  <script>
+  <script type="module">
     // Support multiple examples via ?examples=examples/testimage_0.svg,examples/testimage_1.svg
     const defaultExamples = [
       '/examples/testimage_0.svg',
-      '/examples/testimage_1.svg',
-      '/examples/testimage_2.svg',
-      '/examples/testimage_3.svg',
-      '/examples/testimage_4.svg',
       '/examples/simple_svg_triangle.svg',
       '/examples/triangle-complete-with-jim-metadata.svg',
       '/examples/triangle-with-orphan-selectors.svg',
-      '/examples/Division_of_energy_in_the_Universe.svg',
-      '/examples/Distribution_of_the_workforce_across_economic_sectors_in_India_2019.svg',
-      '/examples/College_enrollment_in_public_and_private_institutions_in_the_U_S__1965_to_2028.svg',
-      '/examples/Number_of_Xbox_Live_MAU_Q1_2016___Q4_2019.svg',
-      '/examples/Unemployment_rate_in_Greece_1999_2019.svg'
+      '/examples/Division_of_energy_in_the_Universe.svg'
     ];
 
     async function parseExamplesFromQueryOrDirectory() {

--- a/tests/auto-load.html
+++ b/tests/auto-load.html
@@ -8,23 +8,78 @@
     body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial; }
     iframe { width: 100vw; height: 100vh; border: none; }
   </style>
+  <style>
+    #controls { position:fixed; left:8px; top:8px; z-index:9999; background:#fff; padding:8px; border-radius:6px; border:1px solid #e2e8f0; box-shadow:0 2px 6px rgba(0,0,0,0.08); }
+    #current { margin:0 8px; font-size:13px; }
+    #controls button { padding:6px 8px; }
+  </style>
 </head>
 <body>
   <!-- This page embeds the single-file viewer and instructs it to load an example SVG so automated a11y tools can scan a populated DOM. -->
+  <div id="controls">
+    <button id="prev" type="button">◀ Prev</button>
+    <span id="current"></span>
+    <button id="next" type="button">Next ▶</button>
+  </div>
   <iframe id="viewer" src="/jim-viewer.html?example=examples/testimage_0.svg" title="JIM Viewer test harness"></iframe>
   <script>
-    // The viewer supports a query param `example` to auto-load an example SVG when present.
-    // If the viewer doesn't support that, this page will still embed it and manual testers can use the UI.
+    // Support multiple examples via ?examples=examples/testimage_0.svg,examples/testimage_1.svg
+    const defaultExamples = [
+      '/examples/testimage_0.svg',
+      '/examples/testimage_1.svg',
+      '/examples/testimage_2.svg'
+    ];
 
-    // For extra robustness, attempt to postMessage the path to the iframe after it loads.
-    const iframe = document.getElementById('viewer');
-    iframe.addEventListener('load', () => {
+    function parseExamplesFromQuery() {
       try {
-        iframe.contentWindow.postMessage({ type: 'autoLoadExample', path: '/examples/testimage_0.svg' }, location.origin);
+        const params = new URLSearchParams(window.location.search);
+        const ex = params.get('examples');
+        if (!ex) return defaultExamples.slice();
+        return ex.split(',').map(s => s.trim()).filter(Boolean).map(p => p.startsWith('/') ? p : '/' + p);
+      } catch (e) {
+        return defaultExamples.slice();
+      }
+    }
+
+    const examples = parseExamplesFromQuery();
+    let idx = 0;
+    const iframe = document.getElementById('viewer');
+    const currentLabel = document.getElementById('current');
+    const prevBtn = document.getElementById('prev');
+    const nextBtn = document.getElementById('next');
+
+    function updateUi() {
+      currentLabel.textContent = `${idx+1} / ${examples.length}`;
+      const path = examples[idx];
+      // Update iframe src query param for compatibility
+      iframe.src = `/jim-viewer.html?example=${encodeURIComponent(path.replace(/^\//,''))}`;
+    }
+
+    function postLoad() {
+      const path = examples[idx];
+      try {
+        iframe.contentWindow.postMessage({ type: 'autoLoadExample', path }, location.origin);
       } catch (e) {
         // ignore cross-origin or timing failures
       }
+    }
+
+    iframe.addEventListener('load', () => {
+      // post the load message once the iframe finishes loading
+      postLoad();
     });
+
+    prevBtn.addEventListener('click', () => {
+      idx = (idx - 1 + examples.length) % examples.length;
+      updateUi();
+    });
+    nextBtn.addEventListener('click', () => {
+      idx = (idx + 1) % examples.length;
+      updateUi();
+    });
+
+    // initialize
+    updateUi();
   </script>
 </body>
 </html>

--- a/tests/auto-load.html
+++ b/tests/auto-load.html
@@ -51,12 +51,27 @@
           try {
             const parser = new DOMParser();
             const doc = parser.parseFromString(text, 'text/html');
-            const links = Array.from(doc.querySelectorAll('a'))
+            let links = Array.from(doc.querySelectorAll('a'))
               .map(a => a.getAttribute('href'))
               .filter(Boolean)
               .filter(h => h.toLowerCase().endsWith('.svg'))
               .map(h => h.startsWith('/') ? h : ('/examples/' + h.replace(/^\.\//, '')));
             if (links.length) return links;
+            // Fallback: some directory listings render filenames without anchor hrefs or use JS templating.
+            // Use a regex to find .svg filenames in the raw HTML as a last resort.
+            const regex = /([\w\-\. \(\)]+?\.svg)/gi;
+            const matches = Array.from(text.matchAll(regex)).map(m => m[1]);
+            if (matches.length) {
+              links = matches.map(h => h.startsWith('/') ? h : ('/examples/' + h.replace(/^\.\//, '')));
+              // dedupe while preserving order
+              const seen = new Set();
+              const unique = [];
+              links.forEach(p => { if (!seen.has(p)) { seen.add(p); unique.push(p); } });
+              if (unique.length) {
+                console.warn('[auto-load] directory listing parse fallback matched files:', unique);
+                return unique;
+              }
+            }
           } catch (e) {
             // fall through to default
           }

--- a/tests/auto-load.html
+++ b/tests/auto-load.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>JIM Previewer - Auto Load Test</title>
+  <style>
+    body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial; }
+    iframe { width: 100vw; height: 100vh; border: none; }
+  </style>
+</head>
+<body>
+  <!-- This page embeds the single-file viewer and instructs it to load an example SVG so automated a11y tools can scan a populated DOM. -->
+  <iframe id="viewer" src="/jim-viewer.html?example=examples/testimage_0.svg" title="JIM Viewer test harness"></iframe>
+  <script>
+    // The viewer supports a query param `example` to auto-load an example SVG when present.
+    // If the viewer doesn't support that, this page will still embed it and manual testers can use the UI.
+
+    // For extra robustness, attempt to postMessage the path to the iframe after it loads.
+    const iframe = document.getElementById('viewer');
+    iframe.addEventListener('load', () => {
+      try {
+        iframe.contentWindow.postMessage({ type: 'autoLoadExample', path: '/examples/testimage_0.svg' }, location.origin);
+      } catch (e) {
+        // ignore cross-origin or timing failures
+      }
+    });
+  </script>
+</body>
+</html>

--- a/tests/auto-load.html
+++ b/tests/auto-load.html
@@ -40,18 +40,43 @@
       '/examples/Unemployment_rate_in_Greece_1999_2019.svg'
     ];
 
-    function parseExamplesFromQuery() {
+    async function parseExamplesFromQueryOrDirectory() {
+      // If examples query param is present, use it (comma-separated)
       try {
         const params = new URLSearchParams(window.location.search);
         const ex = params.get('examples');
-        if (!ex) return defaultExamples.slice();
-        return ex.split(',').map(s => s.trim()).filter(Boolean).map(p => p.startsWith('/') ? p : '/' + p);
+        if (ex) return ex.split(',').map(s => s.trim()).filter(Boolean).map(p => p.startsWith('/') ? p : '/' + p);
       } catch (e) {
-        return defaultExamples.slice();
+        // ignore
       }
+
+      // Try to fetch a directory listing from /examples/ and parse anchor links (http-server provides this)
+      try {
+        const res = await fetch('/examples/');
+        if (res && res.ok) {
+          const text = await res.text();
+          // Attempt to parse HTML and extract hrefs that end with .svg
+          try {
+            const parser = new DOMParser();
+            const doc = parser.parseFromString(text, 'text/html');
+            const links = Array.from(doc.querySelectorAll('a'))
+              .map(a => a.getAttribute('href'))
+              .filter(Boolean)
+              .filter(h => h.toLowerCase().endsWith('.svg'))
+              .map(h => h.startsWith('/') ? h : ('/examples/' + h.replace(/^\.\//, '')));
+            if (links.length) return links;
+          } catch (e) {
+            // fall through to default
+          }
+        }
+      } catch (e) {
+        // network or permission error; fall back to defaults
+      }
+
+      return defaultExamples.slice();
     }
 
-    const examples = parseExamplesFromQuery();
+    let examples = await parseExamplesFromQueryOrDirectory();
     let idx = 0;
     const iframe = document.getElementById('viewer');
     const currentLabel = document.getElementById('current');

--- a/tests/auto-load.html
+++ b/tests/auto-load.html
@@ -4,124 +4,109 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>JIM Previewer - Auto Load Test</title>
+  <!-- Inline tiny SVG favicon to avoid 404 noise from dev servers -->
+  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Crect width='16' height='16' fill='%23ffffff'/%3E%3C/svg%3E">
   <style>
-    body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial; }
-    iframe { width: 100vw; height: 100vh; border: none; }
+    :root { --control-height: 56px; --control-collapsed-height: 36px; }
+    body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial; padding-top: var(--control-height); }
+    /* iframe occupies remaining viewport below the top control bar; its height is adjusted via JS so the top bar can auto-size */
+    iframe { width: 100vw; border: none; display: block; }
   </style>
   <style>
-    #controls { position:fixed; left:8px; top:8px; z-index:9999; background:#fff; padding:8px; border-radius:6px; border:1px solid #e2e8f0; box-shadow:0 2px 6px rgba(0,0,0,0.08); }
+  /* Top-fixed control bar that pushes content down (avoids covering viewer) */
+  #controls { position: fixed; left: 0; right: 0; top: 0; z-index: 9999; background: #fff; padding: 8px 12px; border-bottom:1px solid #e6eef7; box-shadow: 0 2px 6px rgba(0,0,0,0.06); display:flex; align-items:center; gap:12px; box-sizing: border-box; flex-wrap: wrap; min-height: var(--control-height); }
     #current { margin:0 8px; font-size:13px; }
     #controls button { padding:6px 8px; }
+    /* Collapsible control bar */
+  /* Header contains the nav buttons; allow it to take available space so right-side controls don't hug the extreme edge */
+  #controls .controls-header { display:flex; align-items:center; gap:8px; margin:0; flex: 1 1 auto; min-width: 0; }
+  #controls .controls-toggle { background:transparent; border:1px solid #e2e8f0; padding:6px 10px; border-radius:4px; cursor:pointer; }
+  /* When collapsed, shrink the control bar height and hide secondary controls (keeps the handle + index visible) */
+  #controls.collapsed { height: var(--control-collapsed-height); }
+  #controls.collapsed .inspect-row, #controls.collapsed .controls-bottom { display:none; }
+  #controls.collapsed button[id="prev"], #controls.collapsed button[id="next"] { display:none; }
+  #controls.collapsed #current { margin-left:6px; }
+
+  /* When controls wrap, make the inspect row and bottom controls span full width for readability */
+  /* Right-side controls should be pushed to the right without the header stretching */
+  #controls .inspect-row { display: flex; align-items: center; gap:8px; margin-left: 8px; flex: 0 0 auto; max-width: 60%; }
+  /* Lower row spans full width when wrapped */
+  #controls .controls-bottom { display:flex; align-items: center; gap:8px; flex: 1 1 100%; justify-content: flex-start; }
+
+  /* Small screens: allow more vertical space so the iframe isn't overlapped when controls wrap to multiple rows */
+  @media (max-width: 800px) {
+  body { padding-top: 110px; }
+  iframe { /* height will be updated by JS; keep a safe fallback */ height: calc(100vh - 110px); }
+    /* Make controls more compact on narrow viewports */
+    #controls { padding: 6px 8px; gap:8px; }
+    #controls .controls-header { gap:6px; }
+    #controls button { padding:4px 6px; font-size:13px; }
+    /* On narrow viewports the inspect-row should wrap below the header and span full width */
+    #controls .inspect-row { margin-left: 0; flex-basis: 100%; padding-top:6px; }
+    }
+    /* Results panel styles injected by script; defined here to avoid inline styles */
+    .axe-results { position: fixed; right: 8px; bottom: 8px; width: 420px; max-height: 50vh; overflow: auto; background: #fff; border: 1px solid #e2e8f0; padding: 8px; border-radius: 6px; font-size: 12px; }
+    /* Header inside results */
+    .axe-results .results-header { display:flex; justify-content:space-between; align-items:center; margin-bottom:6px; }
+    .axe-results .results-title { font-weight:600; }
+    .axe-results .close-btn { font-size:16px; line-height:1; }
+    .axe-results pre { white-space: pre-wrap; }
+    .axe-results a { display:block; margin-top:8px; }
+    /* Controls lower row */
+    .controls-bottom { margin-top:8px; font-size:13px; }
+    .controls-bottom .muted { margin-left:8px; color: #6b7280; }
   </style>
 </head>
 <body>
   <!-- This page embeds the single-file viewer and instructs it to load an example SVG so automated a11y tools can scan a populated DOM. -->
   <div id="controls">
-    <button id="prev" type="button">◀ Prev</button>
-    <span id="current"></span>
-    <button id="next" type="button">Next ▶</button>
+    <div class="controls-header">
+  <button id="controls-toggle" type="button" class="controls-toggle" aria-label="Toggle test controls">☰</button>
+      <button id="prev" type="button">&lt; Prev</button>
+      <span id="current"></span>
+      <button id="next" type="button">Next &gt;</button>
+    </div>
+    <div class="inspect-row">
+      <input id="inspect-input" type="text" placeholder="selector (e.g. svg #bar)">
+      <button id="inspect-btn" type="button">Inspect</button>
+      <button id="run-axe" type="button">Run axe in iframe</button>
+    </div>
+    <div class="controls-bottom">
+      <label><input id="include-svg" type="checkbox"> Include SVG in scan</label>
+      <span class="muted">(uncheck to skip visual geometry and scan the rest of the page)</span>
+    </div>
   </div>
   <iframe id="viewer" src="/jim-viewer.html?example=examples/testimage_0.svg" title="JIM Viewer test harness"></iframe>
-  <script type="module">
-    // Support multiple examples via ?examples=examples/testimage_0.svg,examples/testimage_1.svg
-    const defaultExamples = [
-      '/examples/testimage_0.svg',
-      '/examples/simple_svg_triangle.svg',
-      '/examples/triangle-complete-with-jim-metadata.svg',
-      '/examples/triangle-with-orphan-selectors.svg',
-      '/examples/Division_of_energy_in_the_Universe.svg'
-    ];
-
-    async function parseExamplesFromQueryOrDirectory() {
-      // If examples query param is present, use it (comma-separated)
-      try {
-        const params = new URLSearchParams(window.location.search);
-        const ex = params.get('examples');
-        if (ex) return ex.split(',').map(s => s.trim()).filter(Boolean).map(p => p.startsWith('/') ? p : '/' + p);
-      } catch (e) {
-        // ignore
-      }
-
-      // Try to fetch a directory listing from /examples/ and parse anchor links (http-server provides this)
-      try {
-        const res = await fetch('/examples/');
-        if (res && res.ok) {
-          const text = await res.text();
-          // Attempt to parse HTML and extract hrefs that end with .svg
-          try {
-            const parser = new DOMParser();
-            const doc = parser.parseFromString(text, 'text/html');
-            let links = Array.from(doc.querySelectorAll('a'))
-              .map(a => a.getAttribute('href'))
-              .filter(Boolean)
-              .filter(h => h.toLowerCase().endsWith('.svg'))
-              .map(h => h.startsWith('/') ? h : ('/examples/' + h.replace(/^\.\//, '')));
-            if (links.length) return links;
-            // Fallback: some directory listings render filenames without anchor hrefs or use JS templating.
-            // Use a regex to find .svg filenames in the raw HTML as a last resort.
-            const regex = /([\w\-\. \(\)]+?\.svg)/gi;
-            const matches = Array.from(text.matchAll(regex)).map(m => m[1]);
-            if (matches.length) {
-              links = matches.map(h => h.startsWith('/') ? h : ('/examples/' + h.replace(/^\.\//, '')));
-              // dedupe while preserving order
-              const seen = new Set();
-              const unique = [];
-              links.forEach(p => { if (!seen.has(p)) { seen.add(p); unique.push(p); } });
-              if (unique.length) {
-                console.warn('[auto-load] directory listing parse fallback matched files:', unique);
-                return unique;
-              }
-            }
-          } catch (e) {
-            // fall through to default
-          }
-        }
-      } catch (e) {
-        // network or permission error; fall back to defaults
-      }
-
-      return defaultExamples.slice();
-    }
-
-    let examples = await parseExamplesFromQueryOrDirectory();
-    let idx = 0;
+  <script>
+  // Keep the page layout in sync with the fixed top controls. When the controls wrap
+  // their height changes; this script updates body padding and iframe height so the
+  // viewer is never overlapped and the control "frame" grows with its contents.
+  (function(){
+    const controls = document.getElementById('controls');
     const iframe = document.getElementById('viewer');
-    const currentLabel = document.getElementById('current');
-    const prevBtn = document.getElementById('prev');
-    const nextBtn = document.getElementById('next');
-
-    function updateUi() {
-      currentLabel.textContent = `${idx+1} / ${examples.length}`;
-      const path = examples[idx];
-      // Update iframe src query param for compatibility
-      iframe.src = `/jim-viewer.html?example=${encodeURIComponent(path.replace(/^\//,''))}`;
+    function updateLayout(){
+      if (!controls) return;
+      const h = controls.offsetHeight;
+      document.body.style.paddingTop = h + 'px';
+      if (iframe) iframe.style.height = `calc(100vh - ${h}px)`;
     }
-
-    function postLoad() {
-      const path = examples[idx];
-      try {
-        iframe.contentWindow.postMessage({ type: 'autoLoadExample', path }, location.origin);
-      } catch (e) {
-        // ignore cross-origin or timing failures
-      }
+    // Initial sync
+    updateLayout();
+    // Watch for size changes using ResizeObserver and window resize as a fallback
+    if (window.ResizeObserver) {
+      const ro = new ResizeObserver(updateLayout);
+      ro.observe(controls);
+      window.addEventListener('resize', updateLayout);
+    } else {
+      window.addEventListener('resize', updateLayout);
+      let last = controls.offsetHeight;
+      setInterval(()=>{ if (controls.offsetHeight !== last) { last = controls.offsetHeight; updateLayout(); } }, 250);
     }
-
-    iframe.addEventListener('load', () => {
-      // post the load message once the iframe finishes loading
-      postLoad();
-    });
-
-    prevBtn.addEventListener('click', () => {
-      idx = (idx - 1 + examples.length) % examples.length;
-      updateUi();
-    });
-    nextBtn.addEventListener('click', () => {
-      idx = (idx + 1) % examples.length;
-      updateUi();
-    });
-
-    // initialize
-    updateUi();
+    // Ensure toggling collapsed state triggers a layout update
+    const toggle = document.getElementById('controls-toggle');
+    if (toggle) toggle.addEventListener('click', ()=> setTimeout(updateLayout, 60));
+  })();
   </script>
+  <script type="module" src="/tests/auto-load.js"></script>
 </body>
 </html>

--- a/tests/auto-load.js
+++ b/tests/auto-load.js
@@ -1,0 +1,297 @@
+// Auto-load harness script extracted from tests/auto-load.html
+// Keeps listeners attached immediately and performs async work in background.
+(function () {
+  'use strict';
+
+  const defaultExamples = [
+    '/examples/testimage_0.svg',
+    '/examples/simple_svg_triangle.svg',
+    '/examples/triangle-complete-with-jim-metadata.svg',
+    '/examples/triangle-with-orphan-selectors.svg',
+    '/examples/Division_of_energy_in_the_Universe.svg'
+  ];
+
+  async function parseExamplesFromQueryOrDirectory() {
+    try {
+      const params = new URLSearchParams(window.location.search);
+      const ex = params.get('examples');
+      if (ex) return ex.split(',').map(s => s.trim()).filter(Boolean).map(p => p.startsWith('/') ? p : '/' + p);
+    } catch (e) { /* ignore */ }
+
+    try {
+      const res = await fetch('/examples/');
+      if (!res || !res.ok) return defaultExamples.slice();
+      const text = await res.text();
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(text, 'text/html');
+      let links = Array.from(doc.querySelectorAll('a'))
+        .map(a => a.getAttribute('href'))
+        .filter(Boolean)
+        .filter(h => h.toLowerCase().endsWith('.svg'))
+        .map(h => h.startsWith('/') ? h : ('/examples/' + h.replace(/^\.\//, '')));
+      if (links.length) return links;
+      // fallback regex
+      const regex = /([\w\-\. \(\)]+?\.svg)/gi;
+      const matches = Array.from(text.matchAll(regex)).map(m => m[1]);
+      if (matches.length) {
+        links = matches.map(h => h.startsWith('/') ? h : ('/examples/' + h.replace(/^\.\//, '')));
+        const seen = new Set();
+        return links.filter(p => seen.has(p) ? false : (seen.add(p), true));
+      }
+    } catch (e) { /* ignore network/parse issues */ }
+    return defaultExamples.slice();
+  }
+
+  // State and elements
+  let examples = defaultExamples.slice();
+  let idx = 0;
+  const iframe = document.getElementById('viewer');
+  const currentLabel = document.getElementById('current');
+  const prevBtn = document.getElementById('prev');
+  const nextBtn = document.getElementById('next');
+  const inspectBtn = document.getElementById('inspect-btn');
+  const inspectInput = document.getElementById('inspect-input');
+  const runAxeBtn = document.getElementById('run-axe');
+  const controls = document.getElementById('controls');
+  const controlsToggle = document.getElementById('controls-toggle');
+
+  // Collapse/expand behavior for the control panel (persisted in localStorage)
+  function setControlsCollapsed(collapsed) {
+    if (!controls) return;
+    controls.classList.toggle('collapsed', !!collapsed);
+    try { localStorage.setItem('autoLoadControlsCollapsed', !!collapsed ? '1' : '0'); } catch (e) { /* ignore */ }
+    try { if (controlsToggle) controlsToggle.setAttribute('aria-expanded', (!!collapsed ? 'false' : 'true')); } catch (e) { /* ignore */ }
+  }
+  // update layout to account for control bar height so iframe remains sized correctly
+  function updateControlHeightVar() {
+    try {
+      const root = document.documentElement;
+      const styles = getComputedStyle(root);
+      const expanded = !controls.classList.contains('collapsed');
+      const h = expanded ? styles.getPropertyValue('--control-height').trim() : styles.getPropertyValue('--control-collapsed-height').trim();
+      // set padding-top and iframe height implicitly handled by CSS variables; if we need to force, set body padding
+      root.style.setProperty('--active-control-height', h || '56px');
+      document.body.style.paddingTop = h || '56px';
+      if (iframe) iframe.style.height = `calc(100vh - ${h || '56px'})`;
+    } catch (e) { /* ignore */ }
+  }
+  // call after state changes
+  const originalSetControlsCollapsed = setControlsCollapsed;
+  setControlsCollapsed = function (collapsed) {
+    originalSetControlsCollapsed(collapsed);
+    updateControlHeightVar();
+  };
+  // ensure layout is correct initially
+  updateControlHeightVar();
+  if (controlsToggle) {
+    controlsToggle.addEventListener('click', () => {
+      const isCollapsed = controls && controls.classList.contains('collapsed');
+      setControlsCollapsed(!isCollapsed);
+    });
+  }
+  // apply saved state
+  try {
+    const saved = localStorage.getItem('autoLoadControlsCollapsed');
+    if (saved === '1') setControlsCollapsed(true);
+  } catch (e) { /* ignore */ }
+
+  function updateUi() {
+    if (currentLabel) currentLabel.textContent = `${idx+1} / ${examples.length}`;
+    const path = examples[idx];
+    if (iframe && path) iframe.src = `/jim-viewer.html?example=${encodeURIComponent(path.replace(/^\//, ''))}`;
+  }
+
+  function postLoad() {
+    const path = examples[idx];
+    try { iframe.contentWindow.postMessage({ type: 'autoLoadExample', path }, location.origin); } catch (e) { /* ignore */ }
+  }
+
+  // Attach listeners immediately (non-blocking)
+  if (iframe) {
+    iframe.addEventListener('load', () => {
+      postLoad();
+      try {
+        const params = new URLSearchParams(window.location.search);
+        const inspectParam = params.get('inspect');
+        const autorun = params.get('autorun');
+        if (inspectParam) {
+          try { iframe.contentWindow.postMessage({ type: 'inspect', selector: inspectParam }, location.origin); } catch (e) {}
+        }
+        if (autorun === '1' || autorun === 'true') {
+          setTimeout(() => { if (runAxeBtn) runAxeBtn.click(); }, 400);
+        }
+      } catch (e) { /* ignore */ }
+    });
+  }
+
+  if (prevBtn) prevBtn.addEventListener('click', () => { if (!examples || !examples.length) return; idx = (idx - 1 + examples.length) % examples.length; updateUi(); });
+  if (nextBtn) nextBtn.addEventListener('click', () => { if (!examples || !examples.length) return; idx = (idx + 1) % examples.length; updateUi(); });
+  if (inspectBtn) inspectBtn.addEventListener('click', () => { const val = inspectInput && inspectInput.value && inspectInput.value.trim(); if (!val) return; try { iframe.contentWindow.postMessage({ type: 'inspect', selector: val }, location.origin); } catch (e) { console.warn('postMessage inspect failed', e); } });
+
+  // Prepare results panel (single instance)
+  let resultsWrap = document.getElementById('axe-results-wrap');
+  if (!resultsWrap) {
+    resultsWrap = document.createElement('div');
+    resultsWrap.id = 'axe-results-wrap';
+    resultsWrap.className = 'axe-results';
+    // start hidden until an axe run is started to avoid showing an empty box on autoload
+    resultsWrap.style.display = 'none';
+    const header = document.createElement('div'); header.className = 'results-header';
+    const title = document.createElement('div'); title.className = 'results-title'; title.textContent = 'axe results';
+    const closeBtn = document.createElement('button'); closeBtn.type = 'button'; closeBtn.setAttribute('aria-label', 'Close axe results'); closeBtn.className = 'close-btn'; closeBtn.textContent = '×'; closeBtn.addEventListener('click', () => { resultsWrap.style.display = 'none'; });
+    header.appendChild(title); header.appendChild(closeBtn); resultsWrap.appendChild(header);
+    const resultsPanel = document.createElement('pre'); resultsPanel.id = 'axe-results-pre'; resultsWrap.appendChild(resultsPanel); document.body.appendChild(resultsWrap);
+  }
+  const resultsPanel = document.getElementById('axe-results-pre');
+
+  // Async init: fetch examples list in background
+  (async () => {
+    try {
+      const found = await parseExamplesFromQueryOrDirectory();
+      if (Array.isArray(found) && found.length) { examples = found; idx = 0; }
+    } catch (e) { console.warn('[auto-load] failed to fetch examples list, using defaults'); }
+    updateUi();
+  })();
+
+  // Axe runner implementation
+  if (runAxeBtn) {
+    runAxeBtn.addEventListener('click', async () => {
+      if (!resultsPanel) return;
+      // reveal the results panel when a run starts
+      if (resultsWrap) resultsWrap.style.display = '';
+      resultsPanel.textContent = 'Running axe...';
+      try {
+        const cwin = iframe.contentWindow;
+        if (!cwin) throw new Error('iframe window not available');
+        if (!cwin.axe) {
+          const script = cwin.document.createElement('script');
+          script.src = 'https://cdnjs.cloudflare.com/ajax/libs/axe-core/4.8.4/axe.min.js';
+          cwin.document.head.appendChild(script);
+          await new Promise((resolve, reject) => { script.onload = resolve; script.onerror = reject; setTimeout(resolve, 3000); });
+        }
+        const includeSVG = document.getElementById('include-svg') && document.getElementById('include-svg').checked;
+        const cdoc = cwin.document;
+        // Build a list of elements we'll hide during the scan (so axe won't evaluate them).
+        // Prefer hiding the visualization container (#visualization) when present; fall back
+        // to common container classes or any inline <svg> elements.
+        const toHide = [];
+        try {
+          if (!includeSVG) {
+            // Common host container inside the viewer that holds the injected SVG
+            const vizContainer = cdoc.getElementById('visualization') || cdoc.querySelector('.viewer-section') || cdoc.querySelector('.visualization');
+            if (vizContainer) {
+              toHide.push(vizContainer);
+            } else {
+              // fallback: hide any inline SVG elements found in the iframe
+              const svgEls = Array.from(cdoc.querySelectorAll('svg'));
+              svgEls.forEach(s => toHide.push(s));
+            }
+          }
+          const dialogEl = cdoc.querySelector('[role="dialog"], .dialog, #dialog, .prev-next, #prev-next');
+          if (dialogEl) toHide.push(dialogEl);
+        } catch (e) { /* ignore DOM query errors */ }
+
+        // Temporarily hide discovered elements (store previous inline style to restore later)
+        const prevStyles = [];
+        try {
+          toHide.forEach(el => {
+            try {
+              prevStyles.push({ el, style: el.getAttribute('style') });
+              // hide visually and from layout; use important to override inline/style sheet rules
+              el.style.setProperty('display', 'none', 'important');
+              // also set aria-hidden for SRs
+              el.setAttribute('aria-hidden', 'true');
+            } catch (e) { /* ignore per-element failures */ }
+          });
+
+          // Run axe on the iframe document (now with excluded elements hidden)
+          const result = await cwin.axe.run(cdoc);
+          // pass result out of try/finally by returning it or assigning to outer scope variable
+          var axeResult = result;
+        } finally {
+          // Restore previous styles/attributes
+          prevStyles.forEach(({ el, style }) => {
+            try {
+              if (style !== null) el.setAttribute('style', style);
+              else el.removeAttribute('style');
+              // remove aria-hidden only if it was added by us (best-effort)
+              if (el.getAttribute('aria-hidden') === 'true') el.removeAttribute('aria-hidden');
+            } catch (e) { /* ignore restore errors */ }
+          });
+        }
+        const result = axeResult;
+
+        // compact summary
+        const makeSummary = (res) => {
+          const counts = { violations: (res.violations||[]).length, incomplete: (res.incomplete||[]).length, passes: (res.passes||[]).length, inapplicable: (res.inapplicable||[]).length };
+          const pickNodes = (arr, n=5) => (arr||[]).slice(0,n).map(rule => ({ id: rule.id, impact: rule.impact, help: rule.help, helpUrl: rule.helpUrl, nodes: (rule.nodes||[]).slice(0,3).map(x => ({ target: x.target, html: (x.html||'').replace(/\s+/g,' ').trim() })) }));
+          return { url: res.url || null, timestamp: res.timestamp || new Date().toISOString(), engine: (res.testEngine && res.testEngine.version) || null, counts, topViolations: pickNodes(res.violations, 6), topIncomplete: pickNodes(res.incomplete, 6), includeSVG: includeSVG };
+        };
+
+        const summary = makeSummary(result);
+        resultsPanel.textContent = '';
+        const header = document.createElement('div'); header.innerHTML = `<div style="margin-bottom:6px"><strong>axe summary</strong> - Violations: ${summary.counts.violations}, Incomplete: ${summary.counts.incomplete}, Passes: ${summary.counts.passes}</div>`; resultsPanel.appendChild(header);
+
+        const renderGroup = (title, items) => {
+          const wrap = document.createElement('div'); const h = document.createElement('div'); h.style.fontWeight = '600'; h.style.marginTop = '8px'; h.textContent = title; wrap.appendChild(h);
+          if (!items || !items.length) { const none = document.createElement('div'); none.textContent = 'none'; none.style.color = '#666'; wrap.appendChild(none); return wrap; }
+          items.forEach(rule => {
+            const r = document.createElement('div'); r.style.marginTop = '6px'; r.innerHTML = `<div><strong>${rule.id}</strong> <small>${rule.impact || ''}</small></div><div style="font-size:12px;color:#333">${rule.help} <a href="${rule.helpUrl}" target="_blank">details</a></div>`;
+            const ul = document.createElement('div');
+            rule.nodes.forEach(n => {
+              const node = document.createElement('div'); node.style.fontSize = '12px'; node.style.marginTop = '4px';
+              const t = document.createElement('pre'); t.style.whiteSpace = 'pre-wrap'; t.style.background = '#fafafa'; t.style.padding = '6px'; t.style.borderRadius = '4px'; t.style.border = '1px solid #eee'; t.textContent = Array.isArray(n.target) ? n.target.join('\n') : String(n.target);
+              const htm = document.createElement('div'); htm.style.marginTop = '4px'; htm.style.fontSize = '12px'; htm.textContent = n.html;
+              node.appendChild(t); node.appendChild(htm); ul.appendChild(node);
+            });
+            r.appendChild(ul); wrap.appendChild(r);
+          });
+          return wrap;
+        };
+
+        resultsPanel.appendChild(renderGroup('Violations (top)', summary.topViolations));
+        resultsPanel.appendChild(renderGroup('Incomplete (top)', summary.topIncomplete));
+
+        // downloads
+        try {
+          const fullBlob = new Blob([JSON.stringify(result, null, 2)], { type: 'application/json' });
+          const fullUrl = URL.createObjectURL(fullBlob);
+          const fullA = document.createElement('a'); fullA.href = fullUrl; fullA.download = 'axe-output.json'; fullA.textContent = 'Download full axe JSON'; fullA.style.display = 'inline-block'; fullA.style.marginTop = '8px'; resultsPanel.appendChild(fullA);
+
+          const sumBlob = new Blob([JSON.stringify(summary, null, 2)], { type: 'application/json' });
+          const sumUrl = URL.createObjectURL(sumBlob);
+          const sumA = document.createElement('a'); sumA.href = sumUrl; sumA.download = 'axe-output-summary.json'; sumA.textContent = 'Download summary JSON'; sumA.style.display = 'inline-block'; sumA.style.marginLeft = '12px'; resultsPanel.appendChild(sumA);
+
+          const makeHtml = (s) => {
+            const esc = (x) => String(x).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+            let html = '<!doctype html><html><head><meta charset="utf-8"><title>Axe summary</title><meta name="viewport" content="width=device-width,initial-scale=1"><style>body{font-family:system-ui,Arial;margin:18px;color:#111}h1,h2{margin:0 0 8px}pre{white-space:pre-wrap;background:#fafafa;padding:8px;border-radius:6px;border:1px solid #eee} .badge{display:inline-block;padding:2px 6px;border-radius:4px;background:#f1f5f9;margin-right:6px;font-size:12px}</style></head><body>';
+            html += `<h1>Axe summary</h1><div><strong>URL:</strong> ${esc(s.url||'N/A')}</div><div><strong>Timestamp:</strong> ${esc(s.timestamp)}</div>`;
+            html += `<div style="margin-top:8px"><span class="badge">Violations: ${s.counts.violations}</span><span class="badge">Incomplete: ${s.counts.incomplete}</span><span class="badge">Passes: ${s.counts.passes}</span></div>`;
+            const render = (title, items) => {
+              html += `<h2>${esc(title)}</h2>`;
+              if (!items || !items.length) { html += `<div style="color:#666">none</div>`; return; }
+              items.forEach(r => {
+                html += `<h3>${esc(r.id)} <small>${esc(r.impact||'')}</small></h3><div>${esc(r.help)} - <a href="${esc(r.helpUrl)}">details</a></div>`;
+                r.nodes.forEach(n => { html += `<pre>${esc(Array.isArray(n.target)?n.target.join('\n'):String(n.target))}</pre><div style="font-size:12px">${esc(n.html)}</div>`; });
+              });
+            };
+            render('Violations (top)', s.topViolations);
+            render('Incomplete (top)', s.topIncomplete);
+            html += '</body></html>';
+            return html;
+          };
+
+          const htmlBlob = new Blob([makeHtml(summary)], { type: 'text/html' });
+          const htmlUrl = URL.createObjectURL(htmlBlob);
+          const openBtn = document.createElement('a'); openBtn.href = htmlUrl; openBtn.target = '_blank'; openBtn.textContent = 'Open summary report (HTML)'; openBtn.style.display = 'inline-block'; openBtn.style.marginLeft = '12px'; resultsPanel.appendChild(openBtn);
+        } catch (e) { /* ignore download errors */ }
+
+      } catch (err) {
+        resultsPanel.textContent = 'Error running axe: ' + (err && err.message ? err.message : String(err));
+      }
+    });
+  } else {
+    console.warn('run-axe button not found; axe runner disabled');
+  }
+
+})();


### PR DESCRIPTION
# chore(ci+accessibility): add Playwright axe smoke runner, harmonize viewer/harness for reliable axe scans

## Summary

This change makes the single-file JIM viewer and the test harness CI-friendly and reduces noisy axe results by ensuring deterministic, contrastable presentation of small decorative swatches. It also adds a Playwright-based smoke helper to run axe across example SVGs and uploads per-example JSON artifacts for review.

Branch: `chore/add-html-validate-ci`

## What changed

- New CI workflow
  - `.github/workflows/axe-playwright.yml` — runs the Playwright axe helper, starts a local static server, writes per-example axe JSON to `axe-output/`, and uploads `axe-output/` as workflow artifacts. Default PR/push behavior is non-failing; manual dispatch can opt-in to failing on violations.
- Playwright-based helper + reporting
  - `scripts/ci-run-axe.js` — helper that uses Playwright to open the viewer, inject axe-core, run axe on each example, and write per-example JSON.
  - `scripts/axe-report.js` — small reporting helper (added).
- Harness and viewer improvements
  - `tests/auto-load.js` — improved harness orchestration: hides visualization/transient UI before axe.run when requested, then restores them.
  - `tests/auto-load.html` — harness page updated to match the change.
  - `jim-viewer.html` — deterministic computed-color swatches, contrast helpers, and UI tweaks so small decorative glyphs do not trigger axe “incomplete” false-positives; preserved behavior so example SVG files are not mutated.
- Project and docs
  - `.gitignore` — added `axe-output/`.
  - `package.json` — added `ci:axe` convenience script and adjusted lint script target.
  - `CI.md`, `CONTRIBUTING.md`, `README.md` — documentation about running the helper and Playwright notes.

## Why

- Reduce spurious axe incomplete/false-positive results caused by tiny decorative glyphs and transient UI.
- Provide a reliable, reproducible smoke test for accessibility that can run locally and in CI and produce per-example artifacts for PR review.
- Avoid mutating example SVGs — the harness hides geometry when needed rather than editing SVG files.

## How it behaves in CI

- By default (push/PR), the workflow runs the Playwright helper and uploads `axe-output/` but does not fail the job on axe violations.
- To force failure when violations exist, trigger the workflow manually via GitHub Actions `Run workflow` and set `fail_on_violations` to `true`. The workflow will then pass `--fail-on-violations=true` to the helper and exit non-zero if violations are found.

## How to run locally (quick)

1. Install dependencies and Playwright browsers:
```powershell
npm ci
npx playwright install --with-deps
```
2. Start a static server and run the helper (one-liner for PowerShell):
```powershell
# Use any static server you prefer; http-server is used in CI workflow
npx http-server ./ -p 8080 -c-1; node scripts/ci-run-axe.js --base-url=http://127.0.0.1:8080 --out-dir=axe-output --fail-on-violations=false
```
3. Inspect results in `axe-output/` (per-example JSON). These files are git-ignored.

## Testing / QA checklist

- [ ] Confirm `jim-viewer.html` UI still functions: open in browser, load local SVG, inspect element panels and announcements.
- [ ] Run `npm run lint:html` — should pass for the project's HTML files.
- [ ] Run the Playwright helper locally (see above) and inspect `axe-output/*.json`.
- [ ] Trigger the workflow manually on GitHub with `fail_on_violations: true` to validate failing behavior if desired.

## Files of interest (high level)

- `jim-viewer.html` — viewer: deterministic swatches + contrast helpers, UI/accessibility tweaks
- `tests/auto-load.js`, `tests/auto-load.html` — harness: axe orchestration and hide/restore logic
- `scripts/ci-run-axe.js`, `scripts/axe-report.js` — Playwright helper + reporter
- `.github/workflows/axe-playwright.yml` — CI workflow
- `.gitignore` — includes `axe-output/`

## Risk, roll-back, and notes

- Risk: none high — the workflow is non-blocking by default. Viewer/harness changes are local UI improvements; they intentionally avoid mutating example SVGs.
- Roll-back: revert the workflow file and the helper scripts; or change workflow dispatch input to keep default non-failing.
- Note: html-validate was tightened to only validate top-level project HTML files to avoid scanning node_modules/Playwright generated files.

## Follow-ups / recommendations

- Decide whether PRs should fail by default on axe violations (I recommend keeping non-failing unless you plan to actively triage/fix example SVG ARIA issues).
- Consider adding a periodic scheduled job to run the axe smoke scans and surface regressions over time.
- If you want stricter CI, I can modify the workflow to fail on violations for all PRs and add a small "known issues" whitelist for currently unavoidable external SVG issues.

## Suggested reviewers and labels

- Reviewers: @frontend, @a11y (or specific team members who usually review UI/CI/a11y)
- Labels: enhancement, ci, accessibility

## Commit/PR note

- This branch contains the combined changes; the key commits are:
  - `ci: add Playwright + axe smoke workflow (upload JSON artifacts)`
  - `ci: allow manual 'fail_on_violations' dispatch to gate failing behavior`
  - `chore: add Playwright axe helper, viewer/harness fixes, docs, and .gitignore`
