### PR TITLE
Updated examples to JIM 0.4.2

### DIFF
--- a/examples/College_enrollment_in_public_and_private_institutions_in_the_U_S__1965_to_2028.svg
+++ b/examples/College_enrollment_in_public_and_private_institutions_in_the_U_S__1965_to_2028.svg
@@ -1592,7 +1592,7 @@ use.visited-mark { pointer-events: none; }
     }
   },
   "version": {
-    "jim": "0.4.0"
+    "jim": "0.4.2"
   }
 }
         </metadata>

--- a/examples/Distribution_of_the_workforce_across_economic_sectors_in_India_2019.svg
+++ b/examples/Distribution_of_the_workforce_across_economic_sectors_in_India_2019.svg
@@ -557,7 +557,7 @@ use.visited-mark { pointer-events: none; }
     }
   },
   "version": {
-    "jim": "0.4.0"
+    "jim": "0.4.2"
   }
 }
         </metadata>

--- a/examples/Division_of_energy_in_the_Universe.svg
+++ b/examples/Division_of_energy_in_the_Universe.svg
@@ -216,7 +216,7 @@ use.visited-mark { pointer-events: none; }
     }
   },
   "version": {
-    "jim": "0.4.0"
+    "jim": "0.4.2"
   }
 }
         </metadata>

--- a/examples/E001-Vertical_Bar_Chart.svg
+++ b/examples/E001-Vertical_Bar_Chart.svg
@@ -36,7 +36,7 @@
     {
       "version": {
         "document": "1.0.1",
-        "jim": "0.4.1"
+        "jim": "0.4.2"
       },
   "datasets": [
     {

--- a/examples/E002-Line_Graph-Monthly_Rainfall.svg
+++ b/examples/E002-Line_Graph-Monthly_Rainfall.svg
@@ -5,7 +5,7 @@
     {
       "version": {
         "document": "1.0.1",
-        "jim": "0.4.1"
+        "jim": "0.4.2"
       },
       "datasets": [
         {
@@ -108,112 +108,112 @@
           "json": "$.datasets[0].facets.y.label",
           "note": "Y-axis label element"
         },
-        "#x-Month": {
+        "x-Month": {
           "dom": "#x-Month",
           "json": "$.datasets[0].facets.x.label",
           "note": "X-axis label element"
         },
-        "#x-axis-line": {
+        "x-axis-line": {
           "dom": "#x-axis-line",
           "json": "$.datasets[0].series[1].records[0].y",
           "note": "X-axis line element"
         },
-        "g.tick-group-y:nth-child(1) use": {
+        "g_tick-group-y-nth-child_1_": {
           "dom": "g.tick-group-y:nth-child(1) use",
           "json": "$.datasets[0].series[1].records[0].y",
           "note": "Y-axis tick 1 element"
         },
-        "g.tick-group-y:nth-child(2) use": {
+        "g_tick-group-y-nth-child_2_": {
           "dom": "g.tick-group-y:nth-child(2) use",
           "json": "$.datasets[0].series[1].records[1].y",
           "note": "Y-axis tick 2 element"
         },
-        "g.tick-group-y:nth-child(3) use": {
+        "g_tick-group-y-nth-child_3_": {
           "dom": "g.tick-group-y:nth-child(3) use",
           "json": "$.datasets[0].series[1].records[2].y",
           "note": "Y-axis tick 3 element"
         },
-        "g.tick-group-y:nth-child(4) use": {
+        "g_tick-group-y-nth-child_4_": {
           "dom": "g.tick-group-y:nth-child(4) use",
           "json": "$.datasets[0].series[1].records[3].y",
           "note": "Y-axis tick 4 element"
         },
-        "g.tick-group-y:nth-child(5) use": {
+        "g_tick-group-y-nth-child_5_": {
           "dom": "g.tick-group-y:nth-child(5) use",
           "json": "$.datasets[0].series[1].records[4].y",
           "note": "Y-axis tick 5 element"
         },
-        "g.tick-group-y:nth-child(6) use": {
+        "g_tick-group-y-nth-child_6_": {
           "dom": "g.tick-group-y:nth-child(6) use",
           "json": "$.datasets[0].series[1].records[5].y",
           "note": "Y-axis tick 6 element"
         },
-        "g.tick-group-y:nth-child(7) use": {
+        "g_tick-group-y-nth-child_7_": {
           "dom": "g.tick-group-y:nth-child(7) use",
           "json": "$.datasets[0].series[1].records[6].y",
           "note": "Y-axis tick 7 element"
         },
-        "#datapoint-rainfall_inches-Mar-4 .chart-point": {
+        "datapoint-rainfall_inches-Mar-4": {
           "dom": "#datapoint-rainfall_inches-Mar-4 .chart-point",
           "json": "$.datasets[0].series[0].records[0].*"
         },
-        "#datapoint-rainfall_inches-Apr-350 .chart-point": {
+        "datapoint-rainfall_inches-Apr-350": {
           "dom": "#datapoint-rainfall_inches-Apr-350 .chart-point",
           "json": "$.datasets[0].series[0].records[1].*"
         },
-        "#datapoint-rainfall_inches-May-450 .chart-point": {
+        "datapoint-rainfall_inches-May-450": {
           "dom": "#datapoint-rainfall_inches-May-450 .chart-point",
           "json": "$.datasets[0].series[0].records[2].*"
         },
-        "#datapoint-rainfall_inches-Jun-4 .chart-point": {
+        "datapoint-rainfall_inches-Jun-4": {
           "dom": "#datapoint-rainfall_inches-Jun-4 .chart-point",
           "json": "$.datasets[0].series[0].records[3].*"
         },
-        "#datapoint-rainfall_inches-Jul-550 .chart-point": {
+        "datapoint-rainfall_inches-Jul-550": {
           "dom": "#datapoint-rainfall_inches-Jul-550 .chart-point",
           "json": "$.datasets[0].series[0].records[4].*"
         },
-        "#datapoint-rainfall_inches-Aug-6 .chart-point": {
+        "datapoint-rainfall_inches-Aug-6": {
           "dom": "#datapoint-rainfall_inches-Aug-6 .chart-point",
           "json": "$.datasets[0].series[0].records[5].*"
         },
-        "#datapoint-rainfall_inches-Sep-5 .chart-point": {
+        "datapoint-rainfall_inches-Sep-5": {
           "dom": "#datapoint-rainfall_inches-Sep-5 .chart-point",
           "json": "$.datasets[0].series[0].records[6].*"
         },
-        "#datapoint-rainfall_inches-Oct-250 .chart-point": {
+        "datapoint-rainfall_inches-Oct-250": {
           "dom": "#datapoint-rainfall_inches-Oct-250 .chart-point",
           "json": "$.datasets[0].series[0].records[7].*"
         },
-        "g.tick-group-x:nth-child(1) text": {
+        "g_tick-group-x-nth-child_1_": {
           "dom": "g.tick-group-x:nth-child(1) text",
           "json": "$.datasets[0].series[0].records[0].x"
         },
-        "g.tick-group-x:nth-child(2) text": {
+        "g_tick-group-x-nth-child_2_": {
           "dom": "g.tick-group-x:nth-child(2) text",
           "json": "$.datasets[0].series[0].records[1].x"
         },
-        "g.tick-group-x:nth-child(3) text": {
+        "g_tick-group-x-nth-child_3_": {
           "dom": "g.tick-group-x:nth-child(3) text",
           "json": "$.datasets[0].series[0].records[2].x"
         },
-        "g.tick-group-x:nth-child(4) text": {
+        "g_tick-group-x-nth-child_4_": {
           "dom": "g.tick-group-x:nth-child(4) text",
           "json": "$.datasets[0].series[0].records[3].x"
         },
-        "g.tick-group-x:nth-child(5) text": {
+        "g_tick-group-x-nth-child_5_": {
           "dom": "g.tick-group-x:nth-child(5) text",
           "json": "$.datasets[0].series[0].records[4].x"
         },
-        "g.tick-group-x:nth-child(6) text": {
+        "g_tick-group-x-nth-child_6_": {
           "dom": "g.tick-group-x:nth-child(6) text",
           "json": "$.datasets[0].series[0].records[5].x"
         },
-        "g.tick-group-x:nth-child(7) text": {
+        "g_tick-group-x-nth-child_7_": {
           "dom": "g.tick-group-x:nth-child(7) text",
           "json": "$.datasets[0].series[0].records[6].x"
         },
-        "g.tick-group-x:nth-child(8) text": {
+        "g_tick-group-x-nth-child_8_": {
           "dom": "g.tick-group-x:nth-child(8) text",
           "json": "$.datasets[0].series[0].records[7].x"
         }

--- a/examples/E004-Number_Line.svg
+++ b/examples/E004-Number_Line.svg
@@ -5,7 +5,7 @@
     {
       "version": {
         "document": "1.0.1",
-        "jim": "0.4.1"
+        "jim": "0.4.2"
       },
       "datasets": [
         {

--- a/examples/JLGjim-photosynthesis-vav-monarch-approved.pdf.svg
+++ b/examples/JLGjim-photosynthesis-vav-monarch-approved.pdf.svg
@@ -17,7 +17,7 @@
   {
     "version": {
       "document": "1.0.1",
-      "jim": "0.4.1"
+      "jim": "0.4.2"
     },
     "datasets": [
       {

--- a/examples/JLGjim-us-midwest-map-monarch-approved.pdf.svg
+++ b/examples/JLGjim-us-midwest-map-monarch-approved.pdf.svg
@@ -17,7 +17,7 @@
 {
   "version": {
     "document": "1.0.1",
-    "jim": "0.4.1"
+    "jim": "0.4.2"
   },
   "datasets": [
     {

--- a/examples/Number_of_Xbox_Live_MAU_Q1_2016___Q4_2019.svg
+++ b/examples/Number_of_Xbox_Live_MAU_Q1_2016___Q4_2019.svg
@@ -356,7 +356,7 @@ use.visited-mark { pointer-events: none; }
     }
   },
   "version": {
-    "jim": "0.4.0"
+    "jim": "0.4.2"
   }
 }
         </metadata>

--- a/examples/Unemployment_rate_in_Greece_1999_2019.svg
+++ b/examples/Unemployment_rate_in_Greece_1999_2019.svg
@@ -408,7 +408,7 @@ use.visited-mark { pointer-events: none; }
     }
   },
   "version": {
-    "jim": "0.4.0"
+    "jim": "0.4.2"
   }
 }
         </metadata>

--- a/examples/right_triangle.svg
+++ b/examples/right_triangle.svg
@@ -66,7 +66,7 @@
     {
       "version": {
         "document": "1.0.1",
-        "jim": "0.4.1"
+        "jim": "0.4.2"
       },
       "datasets": [
         {

--- a/examples/testimage_0.svg
+++ b/examples/testimage_0.svg
@@ -35,7 +35,7 @@ Spec compliance
 <metadata data-type="text/jim+json">
 {
   "version": {
-    "jim": "0.4.1"
+    "jim": "0.4.2"
   },
   "datasets": [
     {

--- a/examples/testimage_1.svg
+++ b/examples/testimage_1.svg
@@ -35,7 +35,7 @@ Spec compliance
   </g>
 <metadata data-type="text/jim+json">{
   "version": {
-    "jim": "0.4.1"
+    "jim": "0.4.2"
   },
   "datasets": [
     {

--- a/examples/testimage_2.svg
+++ b/examples/testimage_2.svg
@@ -45,7 +45,7 @@ Data: {"label":"line-DA","measurement":"undefined"}
   </g>
 <metadata data-type="text/jim+json">{
   "version": {
-    "jim": "0.4.1"
+    "jim": "0.4.2"
   },
   "datasets": [
     {

--- a/examples/testimage_3.svg
+++ b/examples/testimage_3.svg
@@ -46,7 +46,7 @@ Spec compliance
   </g>
 <metadata data-type="text/jim+json">{
   "version": {
-    "jim": "0.4.1"
+    "jim": "0.4.2"
   },
   "datasets": [
     {

--- a/examples/testimage_4.svg
+++ b/examples/testimage_4.svg
@@ -29,7 +29,7 @@
   </g>
 <metadata data-type="text/jim+json">{
   "version": {
-    "jim": "0.4.1"
+    "jim": "0.4.2"
   },
   "datasets": [
     {

--- a/examples/triangle-complete-with-jim-metadata.svg
+++ b/examples/triangle-complete-with-jim-metadata.svg
@@ -186,7 +186,7 @@
         <metadata data-type="text/jim+json">
 {
     "version": {
-        "jim": "0.4.1",
+        "jim": "0.4.2",
         "document": "1.0.0"
     },
     "datasets": [

--- a/examples/triangle-with-orphan-selectors.svg
+++ b/examples/triangle-with-orphan-selectors.svg
@@ -116,7 +116,7 @@
         <metadata data-type="text/jim+json">
 {
     "version": {
-        "jim": "0.4.1",
+        "jim": "0.4.2",
         "document": "1.0.0"
     },
     "datasets": [

--- a/jim-viewer.html
+++ b/jim-viewer.html
@@ -580,6 +580,18 @@
                     if (!jim.selectors || typeof jim.selectors !== 'object' || Array.isArray(jim.selectors)) {
                         errors.push("Missing required property: selectors (object).");
                     } else {
+                        // Validate selector keys against spec: allow ASCII letters, digits, '_' and '-' only (no whitespace)
+                        try {
+                            const selectorKeyRe = /^[A-Za-z0-9_-]+$/;
+                            for (const k of Object.keys(jim.selectors)) {
+                                if (!selectorKeyRe.test(k)) {
+                                    errors.push(`Invalid selector key '${k}'. Selector keys must only contain ASCII letters, digits, '_' or '-' with no whitespace (per JIM spec).`);
+                                }
+                            }
+                        } catch (e) {
+                            // ignore any unexpected issues iterating selector keys
+                        }
+
                         for (const [key, sel] of Object.entries(jim.selectors)) {
                             if (!sel || typeof sel !== 'object') {
                                 errors.push(`Selector '${key}' is not an object (found type: ${typeof sel}).`);


### PR DESCRIPTION
Added a preflight validation that enforces selector keys match the regex /^[A-Za-z0-9_-]+$/. Violations now add a preflight error message instructing authors to use only ASCII letters, digits, '_' or '-' with no whitespace,