### PR TITLE
Golden test added

### DIFF
--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -1,0 +1,98 @@
+# Test Fixtures
+
+This directory contains canonical test fixtures for the JIM Previewer.
+
+## golden.svg
+
+The primary test fixture covering all requirements from `Testing.md`.
+
+### SVG Elements
+
+| ID | Element Type | Visual Style | Purpose |
+|----|--------------|--------------|---------|
+| `#open-path-svg` | `<path>` (open) | 2px stroke, no fill | SVG-only stroke hit testing (has selector + behavior) |
+| `#open-path-overlay` | `<path>` (open) | 2px stroke, no fill | Visual-only element for overlay-enhanced hit testing (no selector) |
+| `#closed-shape` | `<polygon>` | 2px stroke + fill | Visual-only element with stroke+fill, edge-only hit via overlay (no selector) |
+| `#transformed-rect` | `<rect>` in `<g transform>` | stroke + fill | Hit testing under transforms (has selector for implicit announcement) |
+| `#concurrent-target` | `<circle>` | stroke + fill | Haptic + audio concurrency (no selector) |
+| `#repeat-target` | `<rect>` | stroke + fill | repeatInterval + repeatIndex testing (no selector) |
+| `#selector-set-a` | `<circle>` | stroke + fill | JSONPath selector-set member |
+| `#selector-set-b` | `<circle>` | stroke + fill | JSONPath selector-set member |
+| `#implicit-name-test` | `<ellipse>` | stroke + fill | Implicit name fallback when explicit omits name |
+
+### JIM Selectors (4 total)
+
+| Selector Key | DOM Target | JSON Binding | Purpose |
+|--------------|------------|--------------|---------|
+| `targetSet` | `#selector-set-a, #selector-set-b` | `$.datasets[0].series[0].records[0]` | Multi-element selector test |
+| `openPathSvg` | `#open-path-svg` | `$.datasets[0].series[0].records[0]` | SVG-only hit test with data binding |
+| `transformedRect` | `#transformed-rect` | `$.datasets[0].series[0].records[2]` | Implicit announcement from JSONPath |
+| `implicitNameTest` | `#implicit-name-test` | `$.datasets[0].series[0].records[3]` | Explicit description + implicit name fallback |
+
+### Behaviors (10 total)
+
+| # | Target Type | Target | Test Coverage |
+|---|-------------|--------|---------------|
+| 1 | DOM selector | `#open-path-svg` | SVG-only stroke hit (thin 2px), explicit announcement |
+| 2 | Shape overlay | path (20px stroke) | Enhanced hit area over thin visual stroke |
+| 3 | Shape overlay | polygon (15px stroke, no fill) | Edge-only hit on filled SVG shape, enter→details→exit |
+| 4 | DOM selector | `#transformed-rect` | Transform correctness, implicit announcement |
+| 5 | DOM selector | `#selector-set-a, #selector-set-b` | Multi-selector targeting |
+| 6 | DOM selector | `#concurrent-target` | Haptic + audio same event, activate event |
+| 7 | Shape overlay | line (20px stroke) | Stroke-only overlay exclusivity test |
+| 8 | Shape overlay | rect (fill only) | Fill-only overlay exclusivity test, all 3 announcement layers |
+| 9 | DOM selector | `#repeat-target` | repeatInterval + repeatIndex |
+| 10 | DOM selector | `#implicit-name-test` | Explicit description without name → implicit name fallback |
+
+### Test Case Mapping
+
+| Testing.md Requirement | Behavior # | Notes |
+|------------------------|------------|-------|
+| Open path stroke-only hit | 1, 2 | #1 SVG-only (2px), #2 overlay-enhanced (20px hit) |
+| Closed shape hit testing | 3 | SVG has stroke+fill, overlay is edge-only |
+| Fill vs stroke exclusivity | 7, 8 | Stroke-only line vs fill-only rect overlays |
+| Transform correctness | 4 | Element in `<g transform>` |
+| enter → details → exit | 3 | All three events defined |
+| activate independent | 6 | Separate activate block |
+| Haptic + audio concurrency | 6 | Both in enter event |
+| Announcements at behavior level | All | No announcements in event blocks |
+| Implicit name (endpoint) | 4 | From $.datasets[0].series[0].records[2] |
+| Implicit name (wildcard) | 5 | Via multi-selector |
+| Explicit overrides implicit | 1 | Has explicit + data mapping |
+| Explicit omits name → fallback | 10 | Explicit description only, implicit name from data |
+| JSONPath selector-set | 5 | Multi-element selector |
+| repeatInterval + repeatIndex | 9 | Both properties set |
+
+### Hit Testing Design Patterns
+
+1. **SVG-only hit testing** (`#open-path-svg`): Uses thin 2px stroke with a JIM selector binding. Tests native SVG hit detection with both explicit announcement and data binding.
+
+2. **Overlay-enhanced hit testing** (`#open-path-overlay`): Thin 2px visual stroke with NO selector - only the 20px shape overlay provides interaction. The SVG element is purely visual.
+
+3. **Edge-only hit on filled shape** (`#closed-shape`): SVG shows stroke+fill polygon with NO selector - only the stroke-only overlay (15px, no fill) provides interaction. Interior clicks don't trigger - only edge clicks do.
+
+4. **Stroke vs fill exclusivity** (behaviors 7, 8): Separate overlays test that stroke-only shapes don't trigger on interior, and fill-only shapes don't trigger on stroke area.
+
+### Audio Assets
+
+The concurrent test (behavior 6) references:
+- `blop.mp3`
+
+This assumes shared Inclusio audio assets are available.
+
+## Running Tests
+
+1. Open `jim-viewer.html` in a browser
+2. Load `fixtures/golden.svg`
+3. Verify in the Spec Compliance panel:
+   - 0 errors
+   - All 10 behaviors detected
+   - 4 selectors (no orphans)
+4. Interact with each element to verify hit regions and behaviors:
+   - `#open-path-svg`: Only triggers on the thin 2px stroke line
+   - `#open-path-overlay`: Only triggers via the 20px overlay (NOT the thin SVG stroke)
+   - `#closed-shape`: Only triggers on edges via overlay, NOT interior fill
+   - `#transformed-rect`: Triggers correctly despite rotation
+   - `#concurrent-target`: Shows both haptic and audio
+   - `#repeat-target`: Haptic repeats from repeatIndex
+   - `#implicit-name-test`: Shows implicit name ("Implicit Name Fallback") with explicit description

--- a/fixtures/golden.svg
+++ b/fixtures/golden.svg
@@ -1,0 +1,307 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 350">
+  <title>Golden Test Fixture</title>
+  <desc>Canonical fixture for JIM Previewer unit testing. Covers all requirements from Testing.md.</desc>
+
+  <metadata data-type="application/jim+json">
+{
+  "version": {
+    "jim": "1.0.0",
+    "document": "1.0.0"
+  },
+  "datasets": [
+    {
+      "title": "Golden Test Data",
+      "description": "Test data for implicit announcement generation",
+      "facets": {
+        "label": { "type": "categorical", "role": "label" },
+        "x": { "type": "quantitative", "role": "independent" },
+        "y": { "type": "quantitative", "role": "dependent" }
+      },
+      "series": [
+        {
+          "name": "Test Series",
+          "records": [
+            { "label": "Open Path Value", "x": 10, "y": 20 },
+            { "label": "Closed Shape Value", "x": 30, "y": 40 },
+            { "label": "Transformed Rect Value", "x": 50, "y": 60 },
+            { "label": "Implicit Name Fallback", "x": 70, "y": 80 }
+          ]
+        }
+      ]
+    }
+  ],
+  "selectors": {
+    "targetSet": { "dom": "#selector-set-a, #selector-set-b", "json": "$.datasets[0].series[0].records[0]" },
+    "openPathSvg": { "dom": "#open-path-svg", "json": "$.datasets[0].series[0].records[0]" },
+    "transformedRect": { "dom": "#transformed-rect", "json": "$.datasets[0].series[0].records[2]" },
+    "implicitNameTest": { "dom": "#implicit-name-test", "json": "$.datasets[0].series[0].records[3]" }
+  },
+  "behaviors": [
+    {
+      "target": { "selector": "#open-path-svg" },
+      "announcement": {
+        "name": "Open Path (SVG only)",
+        "description": "Thin 2px stroke - tests SVG element hit detection"
+      },
+      "enter": {
+        "haptic": {
+          "durations": [0, 1000, 0, 1000],
+          "repeatInterval": 1000
+        }
+      }
+    },
+    {
+      "target": {
+        "shapes": [
+          {
+            "path": {
+              "d": "M 20,90 L 60,60 L 100,90 L 140,60",
+              "stroke": "#ff6600",
+              "stroke-width": 20,
+              "fill": "none"
+            }
+          }
+        ]
+      },
+      "announcement": {
+        "name": "Open Path (with overlay)",
+        "description": "Thin 2px visual stroke with 20px hit area overlay"
+      },
+      "enter": {
+        "haptic": {
+          "durations": [0, 75, 75, 75, 75, 75, 225],
+          "repeatInterval": 75
+        }
+      }
+    },
+    {
+      "target": {
+        "shapes": [
+          {
+            "polygon": {
+              "points": "180,30 260,30 260,90 180,90",
+              "stroke": "#336699",
+              "stroke-width": 15,
+              "fill": "none"
+            }
+          }
+        ]
+      },
+      "announcement": {
+        "name": "Closed Shape (edge-only)",
+        "description": "SVG has stroke+fill, but overlay is stroke-only for edge-only hit detection"
+      },
+      "enter": {
+        "haptic": {
+          "durations": [0, 75, 75, 75, 75, 75, 225],
+          "repeatInterval": 75
+        }
+      },
+      "details": {
+        "haptic": {
+          "durations": [0, 125, 125, 125, 125, 125, 125, 125],
+          "repeatInterval": 125
+        }
+      },
+      "exit": {
+        "haptic": {
+          "durations": [0, 50, 50, 50, 50, 50, 50, 50, 50, 50, 50, 50, 50, 50, 50, 50, 50, 50, 50, 50],
+          "repeatInterval": 50
+        }
+      }
+    },
+    {
+      "target": { "selector": "#transformed-rect" },
+      "enter": {
+        "haptic": {
+          "durations": [0, 1000, 0, 1000],
+          "repeatInterval": 1000
+        }
+      }
+    },
+    {
+      "target": { "selector": "#selector-set-a, #selector-set-b" },
+      "announcement": {
+        "name": "Selector Set Target"
+      },
+      "enter": {
+        "haptic": {
+          "durations": [0, 75, 75, 75, 75, 75, 225],
+          "repeatInterval": 75
+        }
+      }
+    },
+    {
+      "target": { "selector": "#concurrent-target" },
+      "announcement": {
+        "name": "Concurrent Target",
+        "description": "Tests haptic and audio firing together"
+      },
+      "enter": {
+        "haptic": {
+          "durations": [0, 125, 125, 125, 125, 125, 125, 125],
+          "repeatInterval": 125
+        },
+        "audio": {
+          "href": "blop.mp3"
+        }
+      },
+      "activate": {
+        "haptic": {
+          "durations": [0, 1000, 0, 1000],
+          "repeatInterval": 1000
+        }
+      }
+    },
+    {
+      "target": {
+        "shapes": [
+          {
+            "line": {
+              "x1": 20,
+              "y1": 300,
+              "x2": 120,
+              "y2": 300,
+              "stroke": "#ff0000",
+              "stroke-width": 20,
+              "fill": "none"
+            }
+          }
+        ]
+      },
+      "announcement": {
+        "name": "Stroke-Only Overlay",
+        "description": "Should only trigger on stroke, not fill"
+      },
+      "enter": {
+        "haptic": {
+          "durations": [0, 75, 75, 75, 75, 75, 225],
+          "repeatInterval": 75
+        }
+      }
+    },
+    {
+      "target": {
+        "shapes": [
+          {
+            "rect": {
+              "x": 150,
+              "y": 270,
+              "width": 80,
+              "height": 60,
+              "stroke": "none",
+              "stroke-width": 0,
+              "fill": "#00ff00"
+            }
+          }
+        ]
+      },
+      "announcement": {
+        "name": "Fill-Only Overlay",
+        "description": "Should only trigger on fill, not stroke",
+        "details": "This overlay tests fill-only pointer-events. It has all three announcement layers: name, description, and details."
+      },
+      "enter": {
+        "haptic": {
+          "durations": [0, 1000, 0, 1000],
+          "repeatInterval": 1000
+        }
+      }
+    },
+    {
+      "target": { "selector": "#repeat-target" },
+      "announcement": {
+        "name": "Repeat Target",
+        "description": "Tests repeatInterval and repeatIndex"
+      },
+      "enter": {
+        "haptic": {
+          "durations": [0, 100, 30, 100, 30, 100, 200, 200, 30, 200, 30, 200, 200, 100, 30, 100, 30, 100],
+          "repeatInterval": 100,
+          "repeatIndex": 2
+        }
+      }
+    },
+    {
+      "target": { "selector": "#implicit-name-test" },
+      "announcement": {
+        "description": "This element tests implicit name fallback - explicit announcement has description but no name"
+      },
+      "enter": {
+        "haptic": {
+          "durations": [0, 75, 75, 75, 75, 75, 225],
+          "repeatInterval": 75
+        }
+      }
+    }
+  ],
+  "status": {
+    "features": ["haptic", "audio", "announcement"]
+  }
+}
+  </metadata>
+
+  <style>
+    .thin-stroke { stroke: #333; stroke-width: 2; fill: none; }
+    .filled-shape { stroke: #336699; stroke-width: 2; fill: #6699cc; }
+    .transform-element { stroke: #996633; stroke-width: 2; fill: #ffcc99; }
+    .concurrent-element { stroke: #993399; stroke-width: 2; fill: #cc99ff; }
+    .repeat-element { stroke: #339966; stroke-width: 2; fill: #99ffcc; }
+    .selector-set-element { stroke: #ff6600; stroke-width: 2; fill: #ffcc99; }
+    .implicit-name-element { stroke: #666699; stroke-width: 2; fill: #9999cc; }
+  </style>
+
+  <!-- Test Element 1a: Open path with SVG-only hit detection (thin 2px stroke) -->
+  <path id="open-path-svg" class="thin-stroke"
+        d="M 20,50 L 60,20 L 100,50 L 140,20"
+        stroke-linecap="round" stroke-linejoin="round"/>
+
+  <!-- Test Element 1b: Open path with shape overlay hit enhancement (thin 2px visual, 20px hit area) -->
+  <path id="open-path-overlay" class="thin-stroke"
+        d="M 20,90 L 60,60 L 100,90 L 140,60"
+        stroke-linecap="round" stroke-linejoin="round"/>
+
+  <!-- Test Element 2: Closed shape with stroke+fill visual, but stroke-only overlay for edge-only hit testing -->
+  <polygon id="closed-shape" class="filled-shape"
+           points="180,30 260,30 260,90 180,90"/>
+
+  <!-- Test Element 3: Rectangle under transform for transform correctness -->
+  <g transform="translate(300,20) rotate(15)">
+    <rect id="transformed-rect" class="transform-element"
+          x="0" y="0" width="60" height="40"/>
+  </g>
+
+  <!-- Test Element 4: Circle for concurrent haptic + audio -->
+  <circle id="concurrent-target" class="concurrent-element"
+          cx="70" cy="170" r="30"/>
+
+  <!-- Test Element 5: Rectangle for repeat testing -->
+  <rect id="repeat-target" class="repeat-element"
+        x="140" y="140" width="70" height="50"/>
+
+  <!-- Test Elements 6 & 7: Selector set targets for multi-selector testing -->
+  <circle id="selector-set-a" class="selector-set-element"
+          cx="280" cy="200" r="20"/>
+  <circle id="selector-set-b" class="selector-set-element"
+          cx="340" cy="200" r="20"/>
+
+  <!-- Test Element 8: Ellipse for implicit name fallback testing (explicit has description but no name) -->
+  <ellipse id="implicit-name-test" class="implicit-name-element"
+           cx="310" cy="300" rx="40" ry="25"/>
+
+  <!-- Labels for visual reference (not part of hit testing) -->
+  <g font-family="sans-serif" font-size="9" fill="#666">
+    <text x="20" y="12">open-path-svg (2px, SVG hit)</text>
+    <text x="20" y="115">open-path-overlay (2px visual, 20px hit)</text>
+    <text x="175" y="105">closed-shape (edge-only hit)</text>
+    <text x="290" y="90">transformed-rect</text>
+    <text x="50" y="215">concurrent</text>
+    <text x="145" y="205">repeat</text>
+    <text x="255" y="240">selector-set-a</text>
+    <text x="315" y="240">selector-set-b</text>
+    <text x="275" y="340">implicit-name-test</text>
+    <text x="20" y="330">stroke-only overlay</text>
+    <text x="155" y="345">fill-only overlay</text>
+  </g>
+
+</svg>

--- a/jim-viewer.html
+++ b/jim-viewer.html
@@ -125,14 +125,14 @@
                          - .jim-overlays-visible on #visualization forces overlays visible (stroke shown)
                          - .jim-overlays-hidden on #visualization forces overlays hidden except on hover/focus
                 */
-                .jim-shape-overlay { fill: transparent; stroke-opacity: 0; pointer-events: all; cursor: pointer; transition: stroke-opacity .12s ease, filter .12s ease; }
-                .jim-shape-overlay:focus, .jim-shape-overlay:hover { stroke-opacity: 0.95; filter: drop-shadow(0 1px 4px rgba(0,0,0,0.12)); outline: none; }
+                .jim-shape-overlay { fill-opacity: 0; stroke-opacity: 0; pointer-events: all; cursor: pointer; transition: stroke-opacity .12s ease, fill-opacity .12s ease, filter .12s ease; }
+                .jim-shape-overlay:focus, .jim-shape-overlay:hover { stroke-opacity: 0.95; fill-opacity: 0.5; filter: drop-shadow(0 1px 4px rgba(0,0,0,0.12)); outline: none; }
                 /* Visible state: force overlays visible */
-                .jim-overlays-visible .jim-shape-overlay { stroke-opacity: 0.95; }
+                .jim-overlays-visible .jim-shape-overlay { stroke-opacity: 0.95; fill-opacity: 0.5; }
                 /* Hidden state: keep overlays visually hidden but allow hover/focus to show them */
-                .jim-overlays-hidden .jim-shape-overlay { stroke-opacity: 0; }
+                .jim-overlays-hidden .jim-shape-overlay { stroke-opacity: 0; fill-opacity: 0; }
                 .jim-overlays-hidden .jim-shape-overlay:hover,
-                .jim-overlays-hidden .jim-shape-overlay:focus { stroke-opacity: 0.95; filter: drop-shadow(0 1px 4px rgba(0,0,0,0.12)); }
+                .jim-overlays-hidden .jim-shape-overlay:focus { stroke-opacity: 0.95; fill-opacity: 0.5; filter: drop-shadow(0 1px 4px rgba(0,0,0,0.12)); }
     .badge--muted { background:#e0e7ef; color:#1e293b; padding:2px 6px; margin-right:4px; }
     .muted-note.italic { font-style: italic; color: var(--muted-contrast); }
     .orphaned-list { padding-left:0; margin:8px 0; list-style:none; }
@@ -1398,12 +1398,20 @@
                         overlayEl.removeAttribute('pointer-events');
                         overlayEl.style.removeProperty('pointer-events');
                     } catch (e) { /* ignore */ }
-                    // IMPORTANT: Always force pointer-events to visibleStroke for overlay shapes
-                    // This ensures overlays only capture events on their stroke, not their fill area,
-                    // preventing them from blocking clicks to underlying interactive elements.
-                    // Any pointer-events value from JIM metadata is intentionally ignored.
-                    overlayEl.setAttribute('pointer-events', 'visibleStroke');
-                    overlayEl.style.setProperty('pointer-events', 'visibleStroke', 'important');
+                    // Set pointer-events based on whether shape has stroke, fill, or both
+                    // - stroke-only: visibleStroke (only stroke is clickable)
+                    // - fill-only: visibleFill (only fill is clickable)
+                    // - both: visible (both are clickable)
+                    const hasStroke = payload.stroke && payload.stroke !== 'none' && payload.stroke !== 'transparent';
+                    const hasFill = payload.fill && payload.fill !== 'none' && payload.fill !== 'transparent';
+                    let pointerEventsValue = 'visible';
+                    if (hasStroke && !hasFill) {
+                        pointerEventsValue = 'visibleStroke';
+                    } else if (hasFill && !hasStroke) {
+                        pointerEventsValue = 'visibleFill';
+                    }
+                    overlayEl.setAttribute('pointer-events', pointerEventsValue);
+                    overlayEl.style.setProperty('pointer-events', pointerEventsValue, 'important');
                     overlayEl.setAttribute('tabindex', '0');
                     overlayEl.dataset.behaviorIndex = String(bi);
                     overlayEl.dataset.shapeIndex = String(si);
@@ -1938,6 +1946,26 @@
         }
         const result = flatten(data);
         return result && result.trim() ? result : null;
+    }
+    // Returns the implicit name from data (first label-role field, or 'label' field, or first string field)
+    getImplicitName(data) {
+        if (!data || typeof data !== 'object') return null;
+        const facets = this.jimData?.datasets?.[0]?.facets || {};
+        // Find field with role: label
+        for (const [key, facet] of Object.entries(facets)) {
+            if (facet.role === 'label' && data[key] !== undefined && data[key] !== null) {
+                return String(data[key]).trim();
+            }
+        }
+        // Fallback to 'label' field if present
+        if (data.label !== undefined && data.label !== null) {
+            return String(data.label).trim();
+        }
+        // Fallback to 'name' field if present
+        if (data.name !== undefined && data.name !== null) {
+            return String(data.name).trim();
+        }
+        return null;
     }
     // Simple HTML escaper for injection-safe display
     escapeHtml(str) {
@@ -2739,6 +2767,7 @@
                                 const parts = [];
                                 if (ann.name) parts.push(`Name: ${ann.name}`);
                                 if (ann.description) parts.push(`Description: ${ann.description}`);
+                                if (ann.details) parts.push(`Details: ${ann.details}`);
                                 if (ann.hint) parts.push(`Hint: ${ann.hint}`);
                                 desc = parts.length ? parts.join(' — ') : JSON.stringify(ann);
                             }
@@ -2833,6 +2862,16 @@
                     }
                 }
             }
+            // Get data for implicit name fallback and default announcement
+            let behaviorData = null;
+            let defaultAnn = null;
+            try {
+                const jsonPath = behavior.target?.json;
+                if (jsonPath) {
+                    behaviorData = this.getDataFromJSONPath(jsonPath);
+                    defaultAnn = behaviorData ? this.getDefaultAnnouncement(behaviorData) : null;
+                }
+            } catch (e) { /* ignore */ }
             // Explicit announcement (show name then description if present)
             const explicit = this.getExplicitAnnouncement(behavior);
             if (explicit) {
@@ -2840,25 +2879,26 @@
                 if (typeof explicit === 'string') {
                     html += `<div class="announcement announcement-success"><strong>Explicit Announcement</strong><br>${this.escapeHtml(explicit)}</div>`;
                 } else if (typeof explicit === 'object') {
-                    const name = explicit.name ? String(explicit.name).trim() : null;
+                    let name = explicit.name ? String(explicit.name).trim() : null;
                     const desc = explicit.description ? String(explicit.description).trim() : null;
-                    if (name || desc) {
+                    const details = explicit.details ? String(explicit.details).trim() : null;
+                    // Fallback to implicit name from data if explicit name is missing
+                    const implicitName = this.getImplicitName(behaviorData);
+                    const usedImplicitFallback = !name && implicitName && (desc || details);
+                    if (usedImplicitFallback) name = implicitName;
+                    if (name || desc || details) {
                         html += `<div class="announcement announcement-success"><strong>Explicit Announcement</strong><br>`;
-                        if (name) html += `${this.escapeHtml(name)}`;
+                        if (name) {
+                            html += `${this.escapeHtml(name)}`;
+                            if (usedImplicitFallback) html += ` <span class="muted-note">(from data)</span>`;
+                        }
                         if (desc) html += `<div class="muted-note" style="margin-top:6px">${this.escapeHtml(desc)}</div>`;
+                        if (details) html += `<div class="muted-note" style="margin-top:6px;font-style:italic">${this.escapeHtml(details)}</div>`;
                         html += `</div>`;
                     }
                 }
             }
             // Default announcement from JSON if available
-            let defaultAnn = null;
-            try {
-                const jsonPath = behavior.target?.json;
-                if (jsonPath) {
-                    const data = this.getDataFromJSONPath(jsonPath);
-                    defaultAnn = data ? this.getDefaultAnnouncement(data) : null;
-                }
-            } catch (e) { /* ignore */ }
             if (defaultAnn) html += `<div class="announcement announcement-note"><strong>Default Announcement</strong><br>${this.escapeHtml(defaultAnn)}</div>`;
 
             html += `<details open class="details--spaced"><summary class="details-summary">Behavior JSON</summary><pre class="pre-meta meta-text">${this.escapeHtml(JSON.stringify(behavior, null, 2))}</pre></details>`;
@@ -3231,13 +3271,36 @@
                     <strong>Explicit Announcement:</strong><br>${this.escapeHtml(explicitAnn)}
                 </div>`;
             } else if (typeof explicitAnn === 'object') {
-                const name = explicitAnn.name ? String(explicitAnn.name).trim() : null;
+                let name = explicitAnn.name ? String(explicitAnn.name).trim() : null;
                 const desc = explicitAnn.description ? String(explicitAnn.description).trim() : null;
-                if (name || desc) {
+                const details = explicitAnn.details ? String(explicitAnn.details).trim() : null;
+                // Fallback to implicit name from data if explicit name is missing
+                const implicitName = this.getImplicitName(data);
+                const usedImplicitFallback = !name && implicitName && (desc || details);
+                if (usedImplicitFallback) name = implicitName;
+                if (name || desc || details) {
                     html += `<div class="announcement announcement-success"><strong>Explicit Announcement:</strong><br>`;
-                    if (name) html += `${this.escapeHtml(name)}`;
+                    if (name) {
+                        html += `${this.escapeHtml(name)}`;
+                        if (usedImplicitFallback) html += ` <span class="muted-note">(from data)</span>`;
+                    }
                     if (desc) html += `<div class="muted-note" style="margin-top:6px">${this.escapeHtml(desc)}</div>`;
+                    if (details) html += `<div class="muted-note" style="margin-top:6px;font-style:italic">${this.escapeHtml(details)}</div>`;
                     html += `</div>`;
+                }
+            }
+        }
+        // Show haptic pattern if present in matched behaviors
+        if (matchedBehaviors.length) {
+            const eventKeys = ['enter', 'details', 'activate', 'exit'];
+            for (const behavior of matchedBehaviors) {
+                for (const eventKey of eventKeys) {
+                    if (behavior[eventKey] && behavior[eventKey].haptic) {
+                        const patternName = this.getHapticPatternName(behavior[eventKey].haptic);
+                        if (patternName) {
+                            html += `<div class="announcement announcement-success" style="margin-top:8px"><strong>Haptic Pattern:</strong> "${this.escapeHtml(patternName)}" (${eventKey})</div>`;
+                        }
+                    }
                 }
             }
         }

--- a/tests/auto-load.js
+++ b/tests/auto-load.js
@@ -4,6 +4,7 @@
   'use strict';
 
   const defaultExamples = [
+    '/fixtures/golden.svg',
     '/examples/testimage_0.svg',
     '/examples/simple_svg_triangle.svg',
     '/examples/triangle-complete-with-jim-metadata.svg',


### PR DESCRIPTION
**Fixture created:**

- [fixtures/golden.svg](vscode-webview://1uv0btpag2t3mfm92thqsma6b8r5iugo937jiu7vbtkac91jjgn9/fixtures/golden.svg) - 9 SVG elements, 10 behaviors, 4 selectors
- [fixtures/README.md](vscode-webview://1uv0btpag2t3mfm92thqsma6b8r5iugo937jiu7vbtkac91jjgn9/fixtures/README.md) - Documents test coverage mapping to Testing.md

**Viewer fixes along the way:**

1. **Pointer-events for fill-only overlays** - Fixed overlays to use `visibleFill` instead of always `visibleStroke`
2. **Details field display** - Added `details` extraction to Element Information panel (was only showing name/description)
3. **Implicit name fallback** - Added `getImplicitName()` helper and fallback logic when explicit announcement has description but omits name
4. **Haptic pattern display for selector-bound elements** - Added haptic pattern display to `showElementInfo()` (was only in `showBehaviorInfo()` for overlays)

**Spec questions identified:**

- What field provides implicit name when no `label` field exists?
- What happens when explicit omits name AND no implicit name is available?

The fixture covers all Testing.md requirements and is ready for manual testing via jim-viewer.html.